### PR TITLE
Chore: Add core pack to Github action (#28)

### DIFF
--- a/.github/workflows/certificate-fn-ci.yaml
+++ b/.github/workflows/certificate-fn-ci.yaml
@@ -16,7 +16,7 @@ on:
 permissions:
   contents: read
   id-token: write
-  
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -30,7 +30,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'yarn'
+          cache: "yarn"
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies with Yarn
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
Questa PR aggiunge il COREPACK alla Github Action di CI per andare a correggere un problema di selezione del package manager.

Corepack: È il "gestore dei gestori di pacchetti". È incluso in tutte le versioni recenti di Node.js (come la 22 che usi), ma per ragioni di compatibilità non è abilitato di default.

Il Problema: Senza l'abilitazione di Corepack, la GitHub Action ignora l'istruzione nel package.json e usa la versione di Yarn che trova preinstallata nel sistema, cioè la 1.22.22. In questo modo fallisce.

La Soluzione: Eseguendo corepack enable, attivi questo strumento. A partire da quel momento, quando lanci yarn install, Corepack intercetta il comando, legge il package.json, vede che hai bisogno di yarn@4.6.0, lo scarica e lo usa automaticamente.