### PR TITLE
[SMION-716] Add UAT|PROD on-the-fly

### DIFF
--- a/apps/sm-crm-fn/.env.example
+++ b/apps/sm-crm-fn/.env.example
@@ -1,0 +1,74 @@
+# =============================================================================
+# CONFIGURAZIONE AZURE FUNCTION - SM-CRM-FN
+# =============================================================================
+# 
+# IMPORTANTE: Questo è un file di esempio. NON committare il file .env reale!
+# Copia questo file in `.env` e sostituisci i placeholder con i valori reali.
+#
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Azure Functions Runtime
+# -----------------------------------------------------------------------------
+AzureWebJobsStorage=UseDevelopmentStorage=true
+FUNCTIONS_WORKER_RUNTIME=node
+
+# -----------------------------------------------------------------------------
+# Dynamics 365 CRM Configuration
+# -----------------------------------------------------------------------------
+# URL base del tuo ambiente Dynamics 365 PROD (default)
+# Formato: https://<org-name>.crm<region>.dynamics.com
+# 
+# Questo è l'ambiente utilizzato quando l'header x-dynamics-environment non è fornito
+# o quando è impostato a "PROD".
+DYNAMICS_BASE_URL=https://<your-org>.crm4.dynamics.com
+
+# URL base del tuo ambiente Dynamics 365 UAT
+# Utilizzato quando l'header x-dynamics-environment è impostato a "UAT"
+DYNAMICS_BASE_URL_UAT=https://uat-<your-org>.crm4.dynamics.com
+
+# URL endpoint contatti PROD (opzionale - viene costruito automaticamente)
+# DYNAMICS_URL_CONTACTS=https://<your-org>.crm4.dynamics.com/api/data/v9.2/contacts
+
+# URL endpoint contatti UAT (opzionale - viene costruito automaticamente)
+# DYNAMICS_URL_CONTACTS_UAT=https://uat-<your-org>.crm4.dynamics.com/api/data/v9.2/contacts
+
+# Scope per autenticazione (opzionale - viene costruito automaticamente)
+# DYNAMICS_SCOPE=https://<your-org>.crm4.dynamics.com/.default
+
+# -----------------------------------------------------------------------------
+# Azure AD Authentication (per sviluppo locale)
+# -----------------------------------------------------------------------------
+# Tenant ID Azure AD
+AZURE_TENANT_ID=00000000-0000-0000-0000-000000000000
+
+# Client ID dell'App Registration
+AZURE_CLIENT_ID=00000000-0000-0000-0000-000000000000
+
+# Client Secret (solo per sviluppo locale - in produzione usa Managed Identity)
+# AZURE_CLIENT_SECRET=your-client-secret-here
+
+# -----------------------------------------------------------------------------
+# Environment
+# -----------------------------------------------------------------------------
+# Ambiente di esecuzione: development | production
+NODE_ENV=development
+
+# =============================================================================
+# NOTES
+# =============================================================================
+# 
+# 1. Multi-Environment Support:
+#    - Usa l'header `x-dynamics-environment: UAT` per indirizzare le chiamate all'ambiente UAT
+#    - Usa l'header `x-dynamics-environment: PROD` o ometti l'header per l'ambiente PROD (default)
+#    - Valori accettati: "UAT", "PROD" (case-insensitive)
+# 
+# 2. In PRODUZIONE, usa Azure Managed Identity invece di Client Secret
+# 
+# 3. I valori sensibili vanno configurati nelle Application Settings di Azure
+# 
+# 4. Per lo sviluppo locale, usa il file `.env` (non tracciato da git)
+# 
+# 5. I GUID dei prodotti e team sono configurati in _shared/utils/mappings.ts
+#
+# =============================================================================

--- a/apps/sm-crm-fn/README.md
+++ b/apps/sm-crm-fn/README.md
@@ -88,6 +88,61 @@ Per lo sviluppo locale, configurare le variabili in `local.settings.json`:
 - Per informazioni sugli ambienti, consulta la documentazione interna PagoPA
 - In produzione, configura tutte le variabili sensibili nelle **Application Settings** di Azure
 
+## Supporto Multi-Ambiente (UAT/PROD)
+
+La Function supporta il routing dinamico verso ambienti Dynamics 365 multipli tramite l'header HTTP `x-dynamics-environment`.
+
+### Configurazione
+
+Configura le variabili di ambiente per entrambi gli ambienti Dynamics:
+
+```json
+{
+  "Values": {
+    "DYNAMICS_BASE_URL": "https://<your-prod-org>.crm4.dynamics.com",
+    "DYNAMICS_BASE_URL_UAT": "https://<your-uat-org>.crm4.dynamics.com",
+    "DYNAMICS_URL_CONTACTS": "https://<your-prod-org>.crm4.dynamics.com/api/data/v9.2/contacts",
+    "DYNAMICS_URL_CONTACTS_UAT": "https://<your-uat-org>.crm4.dynamics.com/api/data/v9.2/contacts"
+  }
+}
+```
+
+### Utilizzo
+
+Includi l'header `x-dynamics-environment` nelle richieste HTTP:
+
+```bash
+# Chiamata all'ambiente UAT
+curl -X POST https://<function-url>/api/v1/meetings \
+  -H "x-dynamics-environment: UAT" \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+
+# Chiamata all'ambiente PROD (default)
+curl -X POST https://<function-url>/api/v1/meetings \
+  -H "x-dynamics-environment: PROD" \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+
+# Senza header (default a PROD per retrocompatibilità)
+curl -X POST https://<function-url>/api/v1/meetings \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+```
+
+### Comportamento
+
+- **Valore `UAT`**: Indirizza le chiamate verso `DYNAMICS_BASE_URL_UAT`
+- **Valore `PROD`**: Indirizza le chiamate verso `DYNAMICS_BASE_URL`
+- **Header assente**: Default a `PROD` (retrocompatibilità)
+- **Valore invalido**: Ritorna `400 Bad Request`
+
+**Note:**
+
+- L'header è case-insensitive (`uat`, `UAT`, `Uat` sono tutti validi)
+- L'header `x-dynamics-environment` è supportato su tutti gli endpoint TRANNE `/health`
+- Per testing UAT, assicurati che le credenziali Azure AD abbiano accesso all'ambiente UAT Dynamics
+
 ## API Documentation
 
 La specifica OpenAPI è disponibile in [openapi.yaml](./openapi.yaml).

--- a/apps/sm-crm-fn/README.md
+++ b/apps/sm-crm-fn/README.md
@@ -46,7 +46,6 @@ sm-crm-fn/
 
 | Ambiente | URL                               |
 | -------- | --------------------------------- |
-| DEV      | `https://********.***.****.com`   |
 | UAT      | `https://********.***.****.com`   |
 | PROD     | `https://*********.****.****.com` |
 
@@ -542,6 +541,7 @@ Body:
   "scheduledend": "2025-02-15T11:00:00Z",
   "location": "Google Meet",
   "description": "Discussione requisiti",
+  "nextstep": "Preparare documentazione",
   "dryRun": false
 }
 ```

--- a/apps/sm-crm-fn/README.md
+++ b/apps/sm-crm-fn/README.md
@@ -306,7 +306,9 @@ Content-Type: application/json
   "scheduledend": "2025-02-15T11:00:00Z",
   "location": "Google Meet",
   "description": "Discussione requisiti",
-  "nextstep": "Preparare documentazione",
+  "categoria": "Follow-up tecnico",
+  "dataProssimoContatto": "2025-02-20T10:00:00Z",
+  "oggettoDelContatto": 100000005,
   "dryRun": false
 }
 ```
@@ -541,7 +543,9 @@ Body:
   "scheduledend": "2025-02-15T11:00:00Z",
   "location": "Google Meet",
   "description": "Discussione requisiti",
-  "nextstep": "Preparare documentazione",
+  "categoria": "Follow-up tecnico",
+  "dataProssimoContatto": "2025-02-20T10:00:00Z",
+  "oggettoDelContatto": 100000005,
   "dryRun": false
 }
 ```

--- a/apps/sm-crm-fn/_shared/services/accounts.ts
+++ b/apps/sm-crm-fn/_shared/services/accounts.ts
@@ -16,11 +16,13 @@ import { createLogger, logODataQuery, Timer } from "../utils/logger";
  * Endpoint 1: GET /api/data/v9.2/accounts?$filter=pgp_identificativoselfcare eq '{id}'
  *
  * @param institutionIdSelfcare - ID Selfcare dell'ente
+ * @param baseUrl - Base URL for Dynamics environment
  * @returns Account trovato o null se non esiste
  * @throws Error se trovati più enti (ambiguità)
  */
 export async function getAccountBySelfcareId(
   institutionIdSelfcare: string,
+  baseUrl: string,
 ): Promise<Account | null> {
   const logger = createLogger(undefined, { institutionIdSelfcare });
   const timer = new Timer();
@@ -32,6 +34,7 @@ export async function getAccountBySelfcareId(
     "accountid,name,pgp_identificativoselfcare,pgp_denominazioneselfcare,emailaddress1,telephone1,address1_composite,statecode";
 
   const url = buildUrl({
+    baseUrl,
     endpoint: "/api/data/v9.2/accounts",
     filter,
     select,
@@ -40,7 +43,7 @@ export async function getAccountBySelfcareId(
   logODataQuery(logger, "/api/data/v9.2/accounts", filter, select);
 
   try {
-    const result = await get<Account>(url);
+    const result = await get<Account>(url, baseUrl);
     const duration = timer.elapsed();
 
     // Simple console log for Azure Log Stream visibility
@@ -94,11 +97,13 @@ export async function getAccountBySelfcareId(
  * Endpoint 2: GET /api/data/v9.2/accounts?$filter=contains(tolower(name), '{nome}')
  *
  * @param nomeEnte - Nome dell'ente da cercare
+ * @param baseUrl - Base URL for Dynamics environment
  * @returns Account trovato o null se non esiste
  * @throws Error se trovati più enti (ambiguità)
  */
 export async function getAccountByName(
   nomeEnte: string,
+  baseUrl: string,
 ): Promise<Account | null> {
   const logger = createLogger(undefined, { nomeEnte });
   const timer = new Timer();
@@ -113,6 +118,7 @@ export async function getAccountByName(
     "accountid,name,pgp_identificativoselfcare,pgp_denominazioneselfcare,emailaddress1,telephone1,address1_composite,statecode";
 
   const url = buildUrl({
+    baseUrl,
     endpoint: "/api/data/v9.2/accounts",
     filter,
     select,
@@ -121,7 +127,7 @@ export async function getAccountByName(
   logODataQuery(logger, "/api/data/v9.2/accounts", filter, select);
 
   try {
-    const result = await get<Account>(url);
+    const result = await get<Account>(url, baseUrl);
     const duration = timer.elapsed();
 
     if (!result.value || result.value.length === 0) {
@@ -168,6 +174,7 @@ export interface VerifyAccountParams {
   institutionIdSelfcare?: string;
   nomeEnte?: string;
   enableFallback: boolean;
+  baseUrl: string;
 }
 
 export interface VerifyAccountResult {
@@ -185,6 +192,7 @@ export async function verifyAccount(
     try {
       const account = await getAccountBySelfcareId(
         params.institutionIdSelfcare,
+        params.baseUrl,
       );
       if (account) {
         return { found: true, account, method: "selfcareId" };
@@ -206,7 +214,7 @@ export async function verifyAccount(
   // Fallback su nome ente se ho passato nomeEnte ed enableFallback è true (default false!)
   if (params.nomeEnte && params.enableFallback) {
     try {
-      const account = await getAccountByName(params.nomeEnte);
+      const account = await getAccountByName(params.nomeEnte, params.baseUrl);
       if (account) {
         return { found: true, account, method: "name" };
       }

--- a/apps/sm-crm-fn/_shared/services/appointments.ts
+++ b/apps/sm-crm-fn/_shared/services/appointments.ts
@@ -16,25 +16,30 @@ import { type Logger } from "../utils/logger";
 // -----------------------------------------------------------------------------
 
 /**
- * Lista appuntamenti da Dynamics 365.
+ * Lista tutti gli appuntamenti in Dynamics CRM.
  *
+ * @param baseUrl - Base URL di Dynamics 365
  * @param params - Parametri di query
  * @param params.filter - Filtro OData
  * @param params.select - Campi da selezionare
  * @param params.top - Numero massimo di risultati
  * @param logger - Logger opzionale
- * @param baseUrl - Base URL di Dynamics 365
  * @returns Lista di appuntamenti
  */
 export async function listAppointments(
+  baseUrl: string,
   params?: {
     filter?: string;
     select?: string;
     top?: string;
   },
   logger?: Logger,
-  baseUrl: string = "",
 ): Promise<DynamicsList<Appointment>> {
+  if (!baseUrl) {
+    throw new Error(
+      "listAppointments: baseUrl is required and cannot be empty",
+    );
+  }
   const url = buildUrl({
     baseUrl,
     endpoint: "/api/data/v9.2/appointments",
@@ -220,11 +225,11 @@ export async function listAppointmentsByContact(
   baseUrl: string,
 ): Promise<DynamicsList<Appointment>> {
   return listAppointments(
+    baseUrl,
     {
       filter: `_regardingobjectid_value eq ${contactId}`,
     },
     undefined,
-    baseUrl,
   );
 }
 
@@ -244,10 +249,10 @@ export async function listAppointmentsByAccount(
   baseUrl: string,
 ): Promise<DynamicsList<Appointment>> {
   return listAppointments(
+    baseUrl,
     {
       filter: `_regardingobjectid_value eq ${accountId}`,
     },
     undefined,
-    baseUrl,
   );
 }

--- a/apps/sm-crm-fn/_shared/services/appointments.ts
+++ b/apps/sm-crm-fn/_shared/services/appointments.ts
@@ -16,6 +16,17 @@ import { type Logger } from "../utils/logger";
 // Lista Appuntamenti
 // -----------------------------------------------------------------------------
 
+/**
+ * Lista appuntamenti da Dynamics 365.
+ *
+ * @param params - Parametri di query
+ * @param params.filter - Filtro OData
+ * @param params.select - Campi da selezionare
+ * @param params.top - Numero massimo di risultati
+ * @param logger - Logger opzionale
+ * @param baseUrl - Base URL di Dynamics 365
+ * @returns Lista di appuntamenti
+ */
 export async function listAppointments(
   params?: {
     filter?: string;
@@ -23,8 +34,10 @@ export async function listAppointments(
     top?: string;
   },
   logger?: Logger,
+  baseUrl: string = "",
 ): Promise<DynamicsList<Appointment>> {
   const url = buildUrl({
+    baseUrl,
     endpoint: "/api/data/v9.2/appointments",
     filter: params?.filter,
     select:
@@ -39,7 +52,7 @@ export async function listAppointments(
     odataTop: params?.top,
   });
 
-  return get<Appointment>(url);
+  return get<Appointment>(url, baseUrl);
 }
 
 // -----------------------------------------------------------------------------
@@ -56,18 +69,19 @@ export interface CreateFullAppointmentParams {
   accountId: string;
   contactIds: string[];
   ownerId?: string;
+  baseUrl: string;
 }
 
 /**
  * Crea un Appuntamento in Dynamics con partecipanti.
- * 
+ *
  * Endpoint 6: POST /api/data/v9.2/appointments
- * 
+ *
  * Include automaticamente:
  * - appointment_activity_parties con tutti i contatti e l'account
  * - regardingobjectid_account per collegare all'ente
  * - statuscode: 5 (Busy)
- * 
+ *
  * @param params - Dati dell'appuntamento
  * @param params.subject - Oggetto
  * @param params.scheduledstart - Data/ora inizio (ISO 8601)
@@ -76,13 +90,17 @@ export interface CreateFullAppointmentParams {
  * @param params.contactIds - Array di GUID dei contatti partecipanti
  * @param params.location - Luogo (default: "Meet")
  * @param params.description - Descrizione
+ * @param params.baseUrl - Base URL di Dynamics 365
  * @returns Appuntamento creato con activityid
  */
 export async function createAppointment(
-  params: CreateFullAppointmentParams
+  params: CreateFullAppointmentParams,
 ): Promise<Appointment> {
   const cfg = getConfigOrThrow();
-  const url = `${cfg.DYNAMICS_BASE_URL}/api/data/v9.2/appointments`;
+  const url = buildUrl({
+    baseUrl: params.baseUrl,
+    endpoint: "/api/data/v9.2/appointments",
+  });
 
   // Costruisci activity_parties
   const activityParties: AppointmentParty[] = [];
@@ -123,9 +141,15 @@ export async function createAppointment(
   }
 
   console.log(`[Appointments] Creazione appuntamento: ${params.subject}`);
-  console.log(`[Appointments] Partecipanti: ${params.contactIds.length} contatti + 1 account`);
+  console.log(
+    `[Appointments] Partecipanti: ${params.contactIds.length} contatti + 1 account`,
+  );
 
-  const result = await post<CreateAppointmentRequest, Appointment>(url, body);
+  const result = await post<CreateAppointmentRequest, Appointment>(
+    url,
+    body,
+    params.baseUrl,
+  );
 
   console.log(`[Appointments] Appuntamento creato: ${result.activityid}`);
   return result;
@@ -135,10 +159,19 @@ export async function createAppointment(
 // Get Appuntamento by ID
 // -----------------------------------------------------------------------------
 
+/**
+ * Recupera un appuntamento per ID.
+ *
+ * @param activityId - GUID dell'appuntamento
+ * @param baseUrl - Base URL di Dynamics 365
+ * @returns Appuntamento o null se non trovato
+ */
 export async function getAppointmentById(
-  activityId: string
+  activityId: string,
+  baseUrl: string,
 ): Promise<Appointment | null> {
   const url = buildUrl({
+    baseUrl,
     endpoint: `/api/data/v9.2/appointments(${activityId})`,
     select:
       "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode",
@@ -147,7 +180,7 @@ export async function getAppointmentById(
   console.log(`[Appointments] Fetching appointment: ${activityId}`);
 
   try {
-    const result = await get<Appointment>(url);
+    const result = await get<Appointment>(url, baseUrl);
     return result.value?.[0] ?? (result as unknown as Appointment);
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
@@ -162,22 +195,46 @@ export async function getAppointmentById(
 // Lista Appuntamenti per Contatto
 // -----------------------------------------------------------------------------
 
+/**
+ * Lista appuntamenti per un contatto specifico.
+ *
+ * @param contactId - GUID del contatto
+ * @param baseUrl - Base URL di Dynamics 365
+ * @returns Lista di appuntamenti collegati al contatto
+ */
 export async function listAppointmentsByContact(
-  contactId: string
+  contactId: string,
+  baseUrl: string,
 ): Promise<DynamicsList<Appointment>> {
-  return listAppointments({
-    filter: `_regardingobjectid_value eq ${contactId}`,
-  });
+  return listAppointments(
+    {
+      filter: `_regardingobjectid_value eq ${contactId}`,
+    },
+    undefined,
+    baseUrl,
+  );
 }
 
 // -----------------------------------------------------------------------------
 // Lista Appuntamenti per Account
 // -----------------------------------------------------------------------------
 
+/**
+ * Lista appuntamenti per un account specifico.
+ *
+ * @param accountId - GUID dell'account
+ * @param baseUrl - Base URL di Dynamics 365
+ * @returns Lista di appuntamenti collegati all'account
+ */
 export async function listAppointmentsByAccount(
-  accountId: string
+  accountId: string,
+  baseUrl: string,
 ): Promise<DynamicsList<Appointment>> {
-  return listAppointments({
-    filter: `_regardingobjectid_value eq ${accountId}`,
-  });
+  return listAppointments(
+    {
+      filter: `_regardingobjectid_value eq ${accountId}`,
+    },
+    undefined,
+    baseUrl,
+  );
 }

--- a/apps/sm-crm-fn/_shared/services/appointments.ts
+++ b/apps/sm-crm-fn/_shared/services/appointments.ts
@@ -41,7 +41,7 @@ export async function listAppointments(
     filter: params?.filter,
     select:
       params?.select ??
-      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,pgp_oggettodelcontatto",
+      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,pgp_oggettodelcontatto,category,sortdate",
     top: params?.top,
   });
 
@@ -65,6 +65,8 @@ export interface CreateFullAppointmentParams {
   location?: string;
   description?: string;
   oggettoDelContatto?: number;
+  categoria?: string;
+  dataProssimoContatto?: string;
   accountId: string;
   contactIds: string[];
   ownerId?: string;
@@ -89,7 +91,9 @@ export interface CreateFullAppointmentParams {
  * @param params.contactIds - Array di GUID dei contatti partecipanti
  * @param params.location - Luogo (default: "Meet")
  * @param params.description - Descrizione
- * @param params.oggettoDelContatto - Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365
+ * @param params.oggettoDelContatto - Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365. Default suggerito: 100000005 (Integrazione Tecnica)
+ * @param params.categoria - Categoria appuntamento (campo standard Dynamics)
+ * @param params.dataProssimoContatto - Data prossimo contatto previsto (campo standard Dynamics, formato ISO 8601)
  * @param params.baseUrl - Base URL di Dynamics 365
  * @returns Appuntamento creato con activityid
  */
@@ -139,6 +143,16 @@ export async function createAppointment(
     body.pgp_oggettodelcontatto = params.oggettoDelContatto;
   }
 
+  // Aggiungi categoria se specificata
+  if (params.categoria !== undefined) {
+    body.category = params.categoria;
+  }
+
+  // Aggiungi data prossimo contatto se specificata
+  if (params.dataProssimoContatto !== undefined) {
+    body.sortdate = params.dataProssimoContatto;
+  }
+
   console.log(`[Appointments] Creazione appuntamento: ${params.subject}`);
   console.log(
     `[Appointments] Partecipanti: ${params.contactIds.length} contatti + 1 account`,
@@ -173,7 +187,7 @@ export async function getAppointmentById(
     baseUrl,
     endpoint: `/api/data/v9.2/appointments(${activityId})`,
     select:
-      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,pgp_oggettodelcontatto",
+      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,pgp_oggettodelcontatto,category,sortdate",
   });
 
   console.log(`[Appointments] Fetching appointment: ${activityId}`);

--- a/apps/sm-crm-fn/_shared/services/appointments.ts
+++ b/apps/sm-crm-fn/_shared/services/appointments.ts
@@ -41,7 +41,7 @@ export async function listAppointments(
     filter: params?.filter,
     select:
       params?.select ??
-      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,nextstep,new_dataprossimocontatto,pgp_oggettodelcontatto",
+      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,pgp_oggettodelcontatto",
     top: params?.top,
   });
 
@@ -64,9 +64,7 @@ export interface CreateFullAppointmentParams {
   scheduledend: string;
   location?: string;
   description?: string;
-  nextstep?: string;
-  dataProssimoContatto?: string;
-  oggettoDelContatto?: string;
+  oggettoDelContatto?: number;
   accountId: string;
   contactIds: string[];
   ownerId?: string;
@@ -91,9 +89,7 @@ export interface CreateFullAppointmentParams {
  * @param params.contactIds - Array di GUID dei contatti partecipanti
  * @param params.location - Luogo (default: "Meet")
  * @param params.description - Descrizione
- * @param params.nextstep - Prossimi passi (nextstep field per Dynamics)
- * @param params.dataProssimoContatto - Data prossimo contatto (campo personalizzato Dynamics new_dataprossimocontatto)
- * @param params.oggettoDelContatto - Oggetto del contatto (campo personalizzato Dynamics pgp_oggettodelcontatto)
+ * @param params.oggettoDelContatto - Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365
  * @param params.baseUrl - Base URL di Dynamics 365
  * @returns Appuntamento creato con activityid
  */
@@ -128,7 +124,6 @@ export async function createAppointment(
     scheduledend: params.scheduledend,
     location: params.location ?? "Meet",
     description: params.description,
-    nextstep: params.nextstep,
     statuscode: 5, // Busy
     "regardingobjectid_account@odata.bind": `/accounts(${params.accountId})`,
     appointment_activity_parties: activityParties,
@@ -139,13 +134,8 @@ export async function createAppointment(
     body["ownerid@odata.bind"] = `/systemusers(${params.ownerId})`;
   }
 
-  // Aggiungi data prossimo contatto se specificata
-  if (params.dataProssimoContatto) {
-    body.new_dataprossimocontatto = params.dataProssimoContatto;
-  }
-
   // Aggiungi oggetto del contatto se specificato
-  if (params.oggettoDelContatto) {
+  if (params.oggettoDelContatto !== undefined) {
     body.pgp_oggettodelcontatto = params.oggettoDelContatto;
   }
 
@@ -183,7 +173,7 @@ export async function getAppointmentById(
     baseUrl,
     endpoint: `/api/data/v9.2/appointments(${activityId})`,
     select:
-      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,nextstep,new_dataprossimocontatto,pgp_oggettodelcontatto",
+      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,pgp_oggettodelcontatto",
   });
 
   console.log(`[Appointments] Fetching appointment: ${activityId}`);

--- a/apps/sm-crm-fn/_shared/services/appointments.ts
+++ b/apps/sm-crm-fn/_shared/services/appointments.ts
@@ -9,7 +9,6 @@ import type {
   AppointmentParty,
 } from "../types/dynamics";
 import { get, post, buildUrl } from "./httpClient";
-import { getConfigOrThrow } from "../utils/config";
 import { type Logger } from "../utils/logger";
 
 // -----------------------------------------------------------------------------
@@ -42,7 +41,7 @@ export async function listAppointments(
     filter: params?.filter,
     select:
       params?.select ??
-      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode",
+      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,nextstep,new_dataprossimocontatto,pgp_oggettodelcontatto",
     top: params?.top,
   });
 
@@ -65,7 +64,9 @@ export interface CreateFullAppointmentParams {
   scheduledend: string;
   location?: string;
   description?: string;
+  nextstep?: string;
   dataProssimoContatto?: string;
+  oggettoDelContatto?: string;
   accountId: string;
   contactIds: string[];
   ownerId?: string;
@@ -90,13 +91,15 @@ export interface CreateFullAppointmentParams {
  * @param params.contactIds - Array di GUID dei contatti partecipanti
  * @param params.location - Luogo (default: "Meet")
  * @param params.description - Descrizione
+ * @param params.nextstep - Prossimi passi (nextstep field per Dynamics)
+ * @param params.dataProssimoContatto - Data prossimo contatto (campo personalizzato Dynamics new_dataprossimocontatto)
+ * @param params.oggettoDelContatto - Oggetto del contatto (campo personalizzato Dynamics pgp_oggettodelcontatto)
  * @param params.baseUrl - Base URL di Dynamics 365
  * @returns Appuntamento creato con activityid
  */
 export async function createAppointment(
   params: CreateFullAppointmentParams,
 ): Promise<Appointment> {
-  const cfg = getConfigOrThrow();
   const url = buildUrl({
     baseUrl: params.baseUrl,
     endpoint: "/api/data/v9.2/appointments",
@@ -125,6 +128,7 @@ export async function createAppointment(
     scheduledend: params.scheduledend,
     location: params.location ?? "Meet",
     description: params.description,
+    nextstep: params.nextstep,
     statuscode: 5, // Busy
     "regardingobjectid_account@odata.bind": `/accounts(${params.accountId})`,
     appointment_activity_parties: activityParties,
@@ -138,6 +142,11 @@ export async function createAppointment(
   // Aggiungi data prossimo contatto se specificata
   if (params.dataProssimoContatto) {
     body.new_dataprossimocontatto = params.dataProssimoContatto;
+  }
+
+  // Aggiungi oggetto del contatto se specificato
+  if (params.oggettoDelContatto) {
+    body.pgp_oggettodelcontatto = params.oggettoDelContatto;
   }
 
   console.log(`[Appointments] Creazione appuntamento: ${params.subject}`);
@@ -174,7 +183,7 @@ export async function getAppointmentById(
     baseUrl,
     endpoint: `/api/data/v9.2/appointments(${activityId})`,
     select:
-      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode",
+      "activityid,subject,scheduledstart,scheduledend,location,description,statecode,statuscode,nextstep,new_dataprossimocontatto,pgp_oggettodelcontatto",
   });
 
   console.log(`[Appointments] Fetching appointment: ${activityId}`);

--- a/apps/sm-crm-fn/_shared/services/contacts.ts
+++ b/apps/sm-crm-fn/_shared/services/contacts.ts
@@ -22,12 +22,16 @@ import { createLogger, logODataQuery, Timer } from "../utils/logger";
 // Lista Contatti (usato da ping e altre utility)
 // -----------------------------------------------------------------------------
 
-export async function listContacts(params?: {
-  filter?: string;
-  select?: string;
-  top?: string;
-}): Promise<DynamicsList<Contact>> {
+export async function listContacts(
+  baseUrl: string,
+  params?: {
+    filter?: string;
+    select?: string;
+    top?: string;
+  },
+): Promise<DynamicsList<Contact>> {
   const url = buildUrl({
+    baseUrl,
     endpoint: "/api/data/v9.2/contacts",
     filter: params?.filter,
     select:
@@ -36,7 +40,7 @@ export async function listContacts(params?: {
   });
 
   console.log(`[Contacts] Fetching contacts from: ${url}`);
-  return get<Contact>(url);
+  return get<Contact>(url, baseUrl);
 }
 
 // -----------------------------------------------------------------------------
@@ -44,9 +48,11 @@ export async function listContacts(params?: {
 // -----------------------------------------------------------------------------
 
 export async function getContactById(
+  baseUrl: string,
   contactId: string,
 ): Promise<Contact | null> {
   const url = buildUrl({
+    baseUrl,
     endpoint: `/api/data/v9.2/contacts(${contactId})`,
     select: "contactid,fullname,emailaddress1,firstname,lastname,telephone1",
   });
@@ -54,7 +60,7 @@ export async function getContactById(
   console.log(`[Contacts] Fetching contact: ${contactId}`);
 
   try {
-    const result = await get<Contact>(url);
+    const result = await get<Contact>(url, baseUrl);
     return result.value?.[0] ?? (result as unknown as Contact);
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
@@ -70,9 +76,10 @@ export async function getContactById(
 // -----------------------------------------------------------------------------
 
 export async function searchContactsByEmail(
+  baseUrl: string,
   email: string,
 ): Promise<DynamicsList<Contact>> {
-  return listContacts({
+  return listContacts(baseUrl, {
     filter: `emailaddress1 eq '${email}'`,
   });
 }
@@ -84,10 +91,12 @@ export async function searchContactsByEmail(
 /**
  * Recupera tutti i contatti associati a un Ente (Account).
  *
+ * @param baseUrl - Base URL per le chiamate Dynamics 365
  * @param accountId - GUID dell'account in Dynamics
  * @returns Lista di contatti associati all'ente
  */
 export async function getContactsByAccountId(
+  baseUrl: string,
   accountId: string,
 ): Promise<DynamicsList<Contact>> {
   const logger = createLogger(undefined, { accountId });
@@ -100,6 +109,7 @@ export async function getContactsByAccountId(
     "contactid,fullname,emailaddress1,firstname,lastname,telephone1,pgp_identificativoselfcarecliente,_pgp_prodottoid_value,_parentcustomerid_value,pgp_tipologiareferente";
 
   const url = buildUrl({
+    baseUrl,
     endpoint: "/api/data/v9.2/contacts",
     filter,
     select,
@@ -108,7 +118,7 @@ export async function getContactsByAccountId(
   logODataQuery(logger, "/api/data/v9.2/contacts", filter, select);
 
   try {
-    const result = await get<Contact>(url);
+    const result = await get<Contact>(url, baseUrl);
     const count = result.value?.length ?? 0;
     const duration = timer.elapsed();
 
@@ -156,8 +166,15 @@ export async function getContactsByAccountId(
 
 /**
  * Cerca un Contatto in Dynamics per email, ente e prodotto.
+ *
+ * @param baseUrl - Base URL per le chiamate Dynamics 365
+ * @param email - Email del contatto
+ * @param institutionIdSelfcare - ID Selfcare dell'ente
+ * @param productIdSelfcare - ID Selfcare del prodotto
+ * @returns Contatto trovato o null
  */
 export async function getContactByEmailAndInstitution(
+  baseUrl: string,
   email: string,
   institutionIdSelfcare: string,
   productIdSelfcare: string,
@@ -181,6 +198,7 @@ export async function getContactByEmailAndInstitution(
     "contactid,fullname,emailaddress1,firstname,lastname,telephone1,pgp_identificativoselfcarecliente,_pgp_prodottoid_value,_parentcustomerid_value,pgp_tipologiareferente";
 
   const url = buildUrl({
+    baseUrl,
     endpoint: "/api/data/v9.2/contacts",
     filter,
     select,
@@ -189,7 +207,7 @@ export async function getContactByEmailAndInstitution(
   logODataQuery(logger, "/api/data/v9.2/contacts", filter, select);
 
   try {
-    const result = await get<Contact>(url);
+    const result = await get<Contact>(url, baseUrl);
     const duration = timer.elapsed();
 
     if (!result.value || result.value.length === 0) {
@@ -227,8 +245,14 @@ export async function getContactByEmailAndInstitution(
 
 /**
  * Cerca un Contatto in Dynamics per email e GUID prodotto (fallback).
+ *
+ * @param baseUrl - Base URL per le chiamate Dynamics 365
+ * @param email - Email del contatto
+ * @param productGuidCRM - GUID del prodotto in Dynamics
+ * @returns Contatto trovato o null
  */
 export async function getContactByEmailAndProduct(
+  baseUrl: string,
   email: string,
   productGuidCRM: string,
 ): Promise<Contact | null> {
@@ -249,6 +273,7 @@ export async function getContactByEmailAndProduct(
     "contactid,fullname,emailaddress1,firstname,lastname,telephone1,_pgp_prodottoid_value,_parentcustomerid_value,pgp_tipologiareferente";
 
   const url = buildUrl({
+    baseUrl,
     endpoint: "/api/data/v9.2/contacts",
     filter,
     select,
@@ -257,7 +282,7 @@ export async function getContactByEmailAndProduct(
   logODataQuery(logger, "/api/data/v9.2/contacts", filter, select);
 
   try {
-    const result = await get<Contact>(url);
+    const result = await get<Contact>(url, baseUrl);
     const duration = timer.elapsed();
 
     if (!result.value || result.value.length === 0) {
@@ -302,10 +327,11 @@ export interface CreateContactParams {
 }
 
 export async function createContact(
+  baseUrl: string,
   params: CreateContactParams,
 ): Promise<Contact> {
   const cfg = getConfigOrThrow();
-  const environment = resolveEnvironment(cfg.DYNAMICS_BASE_URL);
+  const environment = resolveEnvironment(baseUrl);
 
   const productGuid = getProductGuid(params.productIdSelfcare, environment);
   if (!productGuid) {
@@ -315,7 +341,7 @@ export async function createContact(
   }
 
   const tipologiaId = getTipologiaReferenteId(params.tipologiaReferente);
-  const url = `${cfg.DYNAMICS_BASE_URL}/api/data/v9.2/contacts`;
+  const url = `${baseUrl}/api/data/v9.2/contacts`;
 
   const body: CreateContactRequest = {
     firstname: params.firstname,
@@ -330,7 +356,7 @@ export async function createContact(
     `[Contacts] Creazione contatto: ${params.firstname} ${params.lastname} <${params.email}>`,
   );
 
-  const result = await post<CreateContactRequest, Contact>(url, body);
+  const result = await post<CreateContactRequest, Contact>(url, body, baseUrl);
 
   console.log(`[Contacts] Contatto creato: ${result.contactid}`);
   return result;
@@ -341,6 +367,7 @@ export async function createContact(
 // -----------------------------------------------------------------------------
 
 export interface VerifyOrCreateContactParams {
+  baseUrl: string;
   email: string;
   nome?: string;
   cognome?: string;
@@ -375,7 +402,7 @@ export async function verifyOrCreateContact(
   });
 
   const cfg = getConfigOrThrow();
-  const environment = resolveEnvironment(cfg.DYNAMICS_BASE_URL);
+  const environment = resolveEnvironment(params.baseUrl);
   const productGuid = getProductGuid(params.productIdSelfcare, environment);
 
   // Step 1: Search by institution
@@ -385,6 +412,7 @@ export async function verifyOrCreateContact(
     });
 
     const contact = await getContactByEmailAndInstitution(
+      params.baseUrl,
       params.email,
       params.institutionIdSelfcare,
       params.productIdSelfcare,
@@ -406,6 +434,7 @@ export async function verifyOrCreateContact(
     logger.debug("Step 2: Fallback search by product GUID", { productGuid });
 
     const contact = await getContactByEmailAndProduct(
+      params.baseUrl,
       params.email,
       productGuid,
     );
@@ -447,7 +476,7 @@ export async function verifyOrCreateContact(
         cognome: params.cognome,
       });
 
-      const newContact = await createContact({
+      const newContact = await createContact(params.baseUrl, {
         firstname: params.nome,
         lastname: params.cognome,
         email: params.email,

--- a/apps/sm-crm-fn/_shared/services/contacts.ts
+++ b/apps/sm-crm-fn/_shared/services/contacts.ts
@@ -15,7 +15,6 @@ import {
   getTipologiaReferenteId,
   resolveEnvironment,
 } from "../utils/mappings";
-import { getConfigOrThrow } from "../utils/config";
 import { createLogger, logODataQuery, Timer } from "../utils/logger";
 
 // -----------------------------------------------------------------------------
@@ -79,8 +78,9 @@ export async function searchContactsByEmail(
   baseUrl: string,
   email: string,
 ): Promise<DynamicsList<Contact>> {
+  const escapedEmail = email.replace(/'/g, "''");
   return listContacts(baseUrl, {
-    filter: `emailaddress1 eq '${email}'`,
+    filter: `emailaddress1 eq '${escapedEmail}'`,
   });
 }
 
@@ -320,7 +320,7 @@ export async function getContactByEmailAndProduct(
 export interface CreateContactParams {
   firstname: string;
   lastname: string;
-  email: string;
+  email?: string;
   productIdSelfcare: ProductIdSelfcare;
   tipologiaReferente: TipologiaReferente;
   accountId: string;
@@ -330,7 +330,6 @@ export async function createContact(
   baseUrl: string,
   params: CreateContactParams,
 ): Promise<Contact> {
-  const cfg = getConfigOrThrow();
   const environment = resolveEnvironment(baseUrl);
 
   const productGuid = getProductGuid(params.productIdSelfcare, environment);
@@ -346,14 +345,18 @@ export async function createContact(
   const body: CreateContactRequest = {
     firstname: params.firstname,
     lastname: params.lastname,
-    emailaddress1: params.email,
     pgp_tipologiareferente: tipologiaId,
     "parentcustomerid_account@odata.bind": `/accounts(${params.accountId})`,
     "pgp_Prodottoid@odata.bind": `/products(${productGuid})`,
   };
 
+  // Solo se email è presente
+  if (params.email) {
+    body.emailaddress1 = params.email;
+  }
+
   console.log(
-    `[Contacts] Creazione contatto: ${params.firstname} ${params.lastname} <${params.email}>`,
+    `[Contacts] Creazione contatto: ${params.firstname} ${params.lastname}${params.email ? ` <${params.email}>` : ""}`,
   );
 
   const result = await post<CreateContactRequest, Contact>(url, body, baseUrl);
@@ -368,7 +371,7 @@ export async function createContact(
 
 export interface VerifyOrCreateContactParams {
   baseUrl: string;
-  email: string;
+  email?: string;
   nome?: string;
   cognome?: string;
   institutionIdSelfcare?: string;
@@ -401,12 +404,11 @@ export async function verifyOrCreateContact(
     enableCreateContact: params.enableCreateContact,
   });
 
-  const cfg = getConfigOrThrow();
   const environment = resolveEnvironment(params.baseUrl);
   const productGuid = getProductGuid(params.productIdSelfcare, environment);
 
-  // Step 1: Search by institution
-  if (params.institutionIdSelfcare) {
+  // Step 1: Search by institution (solo se email è presente)
+  if (params.email && params.institutionIdSelfcare) {
     logger.debug("Step 1: Searching by institution ID and product", {
       institutionId: params.institutionIdSelfcare,
     });
@@ -429,8 +431,8 @@ export async function verifyOrCreateContact(
     logger.debug("Step 1 complete: Contact not found by institution");
   }
 
-  // Step 2: Fallback search by product GUID
-  if (productGuid) {
+  // Step 2: Fallback search by product GUID (solo se email è presente)
+  if (params.email && productGuid) {
     logger.debug("Step 2: Fallback search by product GUID", { productGuid });
 
     const contact = await getContactByEmailAndProduct(
@@ -452,13 +454,22 @@ export async function verifyOrCreateContact(
 
   // Step 3: Create contact if enabled
   if (params.enableCreateContact) {
+    // Loggare warning se email è assente
+    if (!params.email) {
+      logger.warn("⚠️ Creating contact without email address", {
+        hasNome: !!params.nome,
+        hasCognome: !!params.cognome,
+      });
+    }
+
     logger.info("Step 3: Contact creation enabled, attempting to create", {
       hasNome: !!params.nome,
       hasCognome: !!params.cognome,
+      hasEmail: !!params.email,
     });
 
     if (!params.nome || !params.cognome) {
-      const error = `Contatto ${params.email} non trovato e dati insufficienti per la creazione (nome/cognome mancanti)`;
+      const error = `Contatto ${params.email ?? "(senza email)"} non trovato e dati insufficienti per la creazione (nome/cognome mancanti)`;
       logger.warn("⚠️ Cannot create contact: missing name/surname", {
         duration: overallTimer.elapsed(),
       });
@@ -474,6 +485,7 @@ export async function verifyOrCreateContact(
       logger.info("Creating new contact in Dynamics", {
         nome: params.nome,
         cognome: params.cognome,
+        email: params.email ?? "(no email)",
       });
 
       const newContact = await createContact(params.baseUrl, {
@@ -506,7 +518,7 @@ export async function verifyOrCreateContact(
   }
 
   // Contact not found and creation disabled
-  const error = `Contatto ${params.email} non trovato e abilitazione alla creazione disattivata`;
+  const error = `Contatto ${params.email ?? "(senza email)"} non trovato e abilitazione alla creazione disattivata`;
   logger.warn("⚠️ Contact not found and creation is disabled", {
     duration: overallTimer.elapsed(),
   });

--- a/apps/sm-crm-fn/_shared/services/grantAccess.ts
+++ b/apps/sm-crm-fn/_shared/services/grantAccess.ts
@@ -5,7 +5,6 @@
 import type { GrantAccessRequest } from "../types/dynamics";
 import { postAction } from "./httpClient";
 import { getTeamId, resolveEnvironment } from "../utils/mappings";
-import { getConfigOrThrow } from "../utils/config";
 
 // -----------------------------------------------------------------------------
 // Endpoint 7: GrantAccess per Appuntamento
@@ -14,6 +13,7 @@ import { getConfigOrThrow } from "../utils/config";
 export interface GrantAccessParams {
   activityId: string;
   teamId?: string; // Se non specificato, usa il team di default per l'ambiente
+  baseUrl: string;
 }
 
 export interface GrantAccessResult {
@@ -25,32 +25,32 @@ export interface GrantAccessResult {
 
 /**
  * Condivide un Appuntamento con il team Sales per renderlo visibile.
- * 
+ *
  * Endpoint 7: POST /api/data/v9.2/appointments({id})/Microsoft.Dynamics.CRM.GrantAccess
- * 
+ *
  * Senza questa chiamata, l'appuntamento creato via API non è visibile
  * agli utenti del team Sales nella loro vista CRM.
- * 
+ *
  * @param params - Parametri per la condivisione
  * @param params.activityId - GUID dell'appuntamento da condividere
  * @param params.teamId - GUID del team (opzionale, usa default per ambiente)
+ * @param params.baseUrl - Base URL for Dynamics environment
  * @returns Risultato con success/error
- * 
+ *
  * @remarks
  * Se fallisce, l'appuntamento è stato creato ma non sarà visibile.
  * Gestire come warning, non come errore bloccante.
  */
 export async function grantAccessToAppointment(
-  params: GrantAccessParams
+  params: GrantAccessParams,
 ): Promise<GrantAccessResult> {
-  const cfg = getConfigOrThrow();
-  const environment = resolveEnvironment(cfg.DYNAMICS_BASE_URL);
-  
+  const environment = resolveEnvironment(params.baseUrl);
+
   // Usa team specificato o quello di default per l'ambiente
   const teamId = params.teamId ?? getTeamId(environment);
-  
-  const url = `${cfg.DYNAMICS_BASE_URL}/api/data/v9.2/appointments(${params.activityId})/Microsoft.Dynamics.CRM.GrantAccess`;
-  
+
+  const url = `${params.baseUrl}/api/data/v9.2/appointments(${params.activityId})/Microsoft.Dynamics.CRM.GrantAccess`;
+
   const body: GrantAccessRequest = {
     Principal: {
       "teamid@odata.bind": `/teams(${teamId})`,
@@ -58,12 +58,14 @@ export async function grantAccessToAppointment(
     AccessMask: "ReadAccess",
   };
 
-  console.log(`[GrantAccess] Condivisione appuntamento ${params.activityId} con team ${teamId}`);
+  console.log(
+    `[GrantAccess] Condivisione appuntamento ${params.activityId} con team ${teamId}`,
+  );
   console.log(`[GrantAccess] Ambiente: ${environment}`);
 
   try {
-    await postAction(url, body);
-    
+    await postAction(url, body, params.baseUrl);
+
     console.log(`[GrantAccess] ✅ Appuntamento condiviso con successo`);
     return {
       success: true,
@@ -73,7 +75,7 @@ export async function grantAccessToAppointment(
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     console.error(`[GrantAccess] ❌ Errore condivisione: ${msg}`);
-    
+
     return {
       success: false,
       activityId: params.activityId,
@@ -92,19 +94,19 @@ export interface GrantAccessGenericParams {
   entityId: string;
   teamId?: string;
   accessMask?: GrantAccessRequest["AccessMask"];
+  baseUrl: string;
 }
 
 export async function grantAccess(
-  params: GrantAccessGenericParams
+  params: GrantAccessGenericParams,
 ): Promise<GrantAccessResult> {
-  const cfg = getConfigOrThrow();
-  const environment = resolveEnvironment(cfg.DYNAMICS_BASE_URL);
-  
+  const environment = resolveEnvironment(params.baseUrl);
+
   const teamId = params.teamId ?? getTeamId(environment);
   const accessMask = params.accessMask ?? "ReadAccess";
-  
-  const url = `${cfg.DYNAMICS_BASE_URL}/api/data/v9.2/${params.entityName}(${params.entityId})/Microsoft.Dynamics.CRM.GrantAccess`;
-  
+
+  const url = `${params.baseUrl}/api/data/v9.2/${params.entityName}(${params.entityId})/Microsoft.Dynamics.CRM.GrantAccess`;
+
   const body: GrantAccessRequest = {
     Principal: {
       "teamid@odata.bind": `/teams(${teamId})`,
@@ -112,11 +114,13 @@ export async function grantAccess(
     AccessMask: accessMask,
   };
 
-  console.log(`[GrantAccess] Condivisione ${params.entityName}/${params.entityId} con team ${teamId} (${accessMask})`);
+  console.log(
+    `[GrantAccess] Condivisione ${params.entityName}/${params.entityId} con team ${teamId} (${accessMask})`,
+  );
 
   try {
-    await postAction(url, body);
-    
+    await postAction(url, body, params.baseUrl);
+
     return {
       success: true,
       activityId: params.entityId,
@@ -124,7 +128,7 @@ export async function grantAccess(
     };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    
+
     return {
       success: false,
       activityId: params.entityId,

--- a/apps/sm-crm-fn/_shared/services/httpClient.ts
+++ b/apps/sm-crm-fn/_shared/services/httpClient.ts
@@ -17,9 +17,8 @@ import {
 // Headers standard per Dynamics OData API
 // -----------------------------------------------------------------------------
 
-async function getHeaders(): Promise<Record<string, string>> {
-  const cfg = getConfigOrThrow();
-  const scope = buildScope(cfg.DYNAMICS_BASE_URL);
+async function getHeaders(baseUrl: string): Promise<Record<string, string>> {
+  const scope = buildScope(baseUrl);
   const token = await getAccessToken(scope);
 
   return {
@@ -37,6 +36,7 @@ async function getHeaders(): Promise<Record<string, string>> {
 // -----------------------------------------------------------------------------
 
 export interface BuildUrlParams {
+  baseUrl: string;
   endpoint: string;
   filter?: string;
   select?: string;
@@ -45,8 +45,7 @@ export interface BuildUrlParams {
 }
 
 export function buildUrl(params: BuildUrlParams): string {
-  const cfg = getConfigOrThrow();
-  const url = new URL(params.endpoint, cfg.DYNAMICS_BASE_URL);
+  const url = new URL(params.endpoint, params.baseUrl);
 
   if (params.filter) url.searchParams.set("$filter", params.filter);
   if (params.select) url.searchParams.set("$select", params.select);
@@ -116,7 +115,10 @@ function generateMockUuid(): string {
 // HTTP Methods con supporto dry-run
 // -----------------------------------------------------------------------------
 
-export async function get<T>(url: string): Promise<DynamicsList<T>> {
+export async function get<T>(
+  url: string,
+  baseUrl: string,
+): Promise<DynamicsList<T>> {
   const logger = createLogger();
   const timer = new Timer();
 
@@ -147,7 +149,7 @@ export async function get<T>(url: string): Promise<DynamicsList<T>> {
   logHttpRequest(logger, "GET", url);
 
   try {
-    const headers = await getHeaders();
+    const headers = await getHeaders(baseUrl);
     const response = await fetch(url, { method: "GET", headers });
     const duration = timer.elapsed();
 
@@ -232,6 +234,7 @@ function generateMockForEndpoint<T>(url: string): T | null {
 export async function post<TRequest, TResponse>(
   url: string,
   body: TRequest,
+  baseUrl: string,
 ): Promise<TResponse> {
   const logger = createLogger();
   const timer = new Timer();
@@ -264,7 +267,7 @@ export async function post<TRequest, TResponse>(
   logger.debug("POST body", { body });
 
   try {
-    const headers = await getHeaders();
+    const headers = await getHeaders(baseUrl);
     const response = await fetch(url, {
       method: "POST",
       headers,
@@ -321,6 +324,7 @@ export async function post<TRequest, TResponse>(
 export async function postAction<TRequest>(
   url: string,
   body: TRequest,
+  baseUrl: string,
 ): Promise<void> {
   if (dryRunContext.enabled) {
     console.log(`🧪 [DRY-RUN] POST (Action) ${url}`);
@@ -329,7 +333,7 @@ export async function postAction<TRequest>(
     return;
   }
 
-  const headers = await getHeaders();
+  const headers = await getHeaders(baseUrl);
   const response = await fetch(url, {
     method: "POST",
     headers,

--- a/apps/sm-crm-fn/_shared/services/orchestrator.ts
+++ b/apps/sm-crm-fn/_shared/services/orchestrator.ts
@@ -373,8 +373,6 @@ export async function createMeetingOrchestrator(
         scheduledend: request.scheduledend,
         location: request.location,
         description: request.description,
-        nextstep: request.nextstep,
-        dataProssimoContatto: request.dataProssimoContatto,
         oggettoDelContatto: request.oggettoDelContatto,
         accountId,
         contactIds,

--- a/apps/sm-crm-fn/_shared/services/orchestrator.ts
+++ b/apps/sm-crm-fn/_shared/services/orchestrator.ts
@@ -588,13 +588,21 @@ export function validateOrchestratorRequest(
   } else {
     for (let i = 0; i < req.partecipanti.length; i++) {
       const p = req.partecipanti[i] as Record<string, unknown>;
+
+      // Valida sempre il tipo di email se presente
+      if (p.email !== undefined && typeof p.email !== "string") {
+        errors.push(`partecipanti[${i}].email deve essere una stringa`);
+        continue; // Skip ulteriori validazioni su questa email
+      }
+
       // Validazione formato email opzionale (feature flag ENABLE_EMAIL_FORMAT_VALIDATION)
       if (
         p.email &&
+        typeof p.email === "string" &&
         process.env.ENABLE_EMAIL_FORMAT_VALIDATION?.toLowerCase() === "true"
       ) {
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (typeof p.email !== "string" || !emailRegex.test(p.email)) {
+        if (!emailRegex.test(p.email)) {
           errors.push(
             `partecipanti[${i}].email non è un indirizzo email valido`,
           );

--- a/apps/sm-crm-fn/_shared/services/orchestrator.ts
+++ b/apps/sm-crm-fn/_shared/services/orchestrator.ts
@@ -254,29 +254,29 @@ export async function createMeetingOrchestrator(
         if (contactResult.contact) {
           contactIds.push(contactResult.contact.contactid);
           contactResults.push({
-            email: partecipante.email,
+            email: partecipante.email ?? "(no email)",
             contactId: contactResult.contact.contactid,
             created: contactResult.created,
           });
           logger.info(
             `✅ Contact ${contactResult.created ? "created" : "found"}`,
             {
-              email: partecipante.email,
+              email: partecipante.email ?? "(no email)",
               contactId: contactResult.contact.contactid,
               created: contactResult.created,
             },
           );
         } else {
           contactResults.push({
-            email: partecipante.email,
+            email: partecipante.email ?? "(no email)",
             created: false,
             error: contactResult.error,
           });
           warnings.push(
-            `Contatto ${partecipante.email}: ${contactResult.error}`,
+            `Contatto ${partecipante.email ?? "(senza email)"}: ${contactResult.error}`,
           );
           logger.warn(`⚠️ Contact processing failed`, {
-            email: partecipante.email,
+            email: partecipante.email ?? "(no email)",
             error: contactResult.error,
           });
         }
@@ -373,7 +373,9 @@ export async function createMeetingOrchestrator(
         scheduledend: request.scheduledend,
         location: request.location,
         description: request.description,
+        nextstep: request.nextstep,
         dataProssimoContatto: request.dataProssimoContatto,
+        oggettoDelContatto: request.oggettoDelContatto,
         accountId,
         contactIds,
         baseUrl: request.baseUrl,
@@ -586,8 +588,17 @@ export function validateOrchestratorRequest(
   } else {
     for (let i = 0; i < req.partecipanti.length; i++) {
       const p = req.partecipanti[i] as Record<string, unknown>;
-      if (!p.email) {
-        errors.push(`partecipanti[${i}].email è obbligatorio`);
+      // Validazione formato email opzionale (feature flag ENABLE_EMAIL_FORMAT_VALIDATION)
+      if (
+        p.email &&
+        process.env.ENABLE_EMAIL_FORMAT_VALIDATION?.toLowerCase() === "true"
+      ) {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (typeof p.email !== "string" || !emailRegex.test(p.email)) {
+          errors.push(
+            `partecipanti[${i}].email non è un indirizzo email valido`,
+          );
+        }
       }
     }
   }

--- a/apps/sm-crm-fn/_shared/services/orchestrator.ts
+++ b/apps/sm-crm-fn/_shared/services/orchestrator.ts
@@ -31,10 +31,23 @@ import { createLogger, Timer } from "../utils/logger";
  * 4. GrantAccess per visibilità team Sales
  *
  * @param request - Dati per la creazione dell'appuntamento
+ * @param request.baseUrl - Base URL for Dynamics 365 environment (e.g., "https://org.crm4.dynamics.com")
+ * @param request.institutionIdSelfcare - ID Selfcare dell'ente
+ * @param request.nomeEnte - Nome dell'ente (opzionale, usato come fallback)
+ * @param request.productIdSelfcare - ID del prodotto Selfcare
+ * @param request.partecipanti - Array di partecipanti all'appuntamento
+ * @param request.subject - Oggetto dell'appuntamento
+ * @param request.scheduledstart - Data/ora inizio (ISO 8601)
+ * @param request.scheduledend - Data/ora fine (ISO 8601)
+ * @param request.enableFallback - Abilita ricerca ente per nome se ID non trovato
+ * @param request.enableCreateContact - Abilita creazione automatica contatti
+ * @param request.enableGrantAccess - Abilita condivisione con team Sales
+ * @param request.dryRun - Modalità dry-run (no modifiche a Dynamics)
  * @returns Risultato dell'orchestrazione con dettaglio di ogni step
  *
  * @example
  * const result = await createMeetingOrchestrator({
+ *   baseUrl: "https://org.crm4.dynamics.com",
  *   institutionIdSelfcare: "uuid-ente",
  *   productIdSelfcare: "prod-pagopa",
  *   partecipanti: [{ email: "mario@ente.it", nome: "Mario", cognome: "Rossi" }],
@@ -101,6 +114,7 @@ export async function createMeetingOrchestrator(
         institutionIdSelfcare: request.institutionIdSelfcare,
         nomeEnte: request.nomeEnte,
         enableFallback: request.enableFallback ?? false,
+        baseUrl: request.baseUrl,
       });
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -214,6 +228,7 @@ export async function createMeetingOrchestrator(
         );
 
         const contactResult = await verifyOrCreateContact({
+          baseUrl: request.baseUrl,
           email: partecipante.email,
           nome: partecipante.nome,
           cognome: partecipante.cognome,
@@ -361,6 +376,7 @@ export async function createMeetingOrchestrator(
         dataProssimoContatto: request.dataProssimoContatto,
         accountId,
         contactIds,
+        baseUrl: request.baseUrl,
       });
 
       steps.push({
@@ -412,6 +428,7 @@ export async function createMeetingOrchestrator(
       const grantTimer = new Timer();
       const grantResult = await grantAccessToAppointment({
         activityId: appointment.activityid,
+        baseUrl: request.baseUrl,
       });
 
       steps.push({

--- a/apps/sm-crm-fn/_shared/services/orchestrator.ts
+++ b/apps/sm-crm-fn/_shared/services/orchestrator.ts
@@ -374,6 +374,8 @@ export async function createMeetingOrchestrator(
         location: request.location,
         description: request.description,
         oggettoDelContatto: request.oggettoDelContatto,
+        categoria: request.categoria,
+        dataProssimoContatto: request.dataProssimoContatto,
         accountId,
         contactIds,
         baseUrl: request.baseUrl,

--- a/apps/sm-crm-fn/_shared/types/dynamics.ts
+++ b/apps/sm-crm-fn/_shared/types/dynamics.ts
@@ -48,9 +48,8 @@ export interface Appointment {
   description?: string;
   statecode?: number;
   statuscode?: number;
-  nextstep?: string;
-  new_dataprossimocontatto?: string;
-  pgp_oggettodelcontatto?: string;
+  /** Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365 */
+  pgp_oggettodelcontatto?: number;
 }
 
 // -----------------------------------------------------------------------------
@@ -73,10 +72,9 @@ export interface CreateAppointmentRequest {
   scheduledend: string;
   location?: string;
   description?: string;
-  nextstep?: string;
   statuscode?: number;
-  new_dataprossimocontatto?: string;
-  pgp_oggettodelcontatto?: string;
+  /** Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365 */
+  pgp_oggettodelcontatto?: number;
   "ownerid@odata.bind"?: string;
   "regardingobjectid_account@odata.bind"?: string;
   appointment_activity_parties?: AppointmentParty[];
@@ -149,9 +147,8 @@ export interface CreateMeetingOrchestratorRequest {
   scheduledend: string;
   location?: string;
   description?: string;
-  nextstep?: string;
-  dataProssimoContatto?: string;
-  oggettoDelContatto?: string;
+  /** Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365 */
+  oggettoDelContatto?: number;
 
   // Opzioni
   dryRun?: boolean;

--- a/apps/sm-crm-fn/_shared/types/dynamics.ts
+++ b/apps/sm-crm-fn/_shared/types/dynamics.ts
@@ -48,7 +48,9 @@ export interface Appointment {
   description?: string;
   statecode?: number;
   statuscode?: number;
+  nextstep?: string;
   new_dataprossimocontatto?: string;
+  pgp_oggettodelcontatto?: string;
 }
 
 // -----------------------------------------------------------------------------
@@ -58,7 +60,7 @@ export interface Appointment {
 export interface CreateContactRequest {
   firstname: string;
   lastname: string;
-  emailaddress1: string;
+  emailaddress1?: string;
   pgp_tipologiareferente: number;
   // Navigation Properties for lookups (use @odata.bind)
   "parentcustomerid_account@odata.bind": string;
@@ -71,8 +73,10 @@ export interface CreateAppointmentRequest {
   scheduledend: string;
   location?: string;
   description?: string;
+  nextstep?: string;
   statuscode?: number;
   new_dataprossimocontatto?: string;
+  pgp_oggettodelcontatto?: string;
   "ownerid@odata.bind"?: string;
   "regardingobjectid_account@odata.bind"?: string;
   appointment_activity_parties?: AppointmentParty[];
@@ -120,7 +124,7 @@ export interface DynamicsError {
 // -----------------------------------------------------------------------------
 
 export interface Partecipante {
-  email: string;
+  email?: string;
   nome?: string;
   cognome?: string;
   tipologiaReferente?: TipologiaReferente;
@@ -145,7 +149,9 @@ export interface CreateMeetingOrchestratorRequest {
   scheduledend: string;
   location?: string;
   description?: string;
+  nextstep?: string;
   dataProssimoContatto?: string;
+  oggettoDelContatto?: string;
 
   // Opzioni
   dryRun?: boolean;
@@ -211,4 +217,4 @@ export type ProductIdSelfcare =
   | "prod-io-sign"
   | "prod-rtp";
 
-export type Environment = "DEV" | "UAT" | "PROD";
+export type Environment = "UAT" | "PROD";

--- a/apps/sm-crm-fn/_shared/types/dynamics.ts
+++ b/apps/sm-crm-fn/_shared/types/dynamics.ts
@@ -155,6 +155,13 @@ export interface CreateMeetingOrchestratorRequest {
    * @default false
    */
   enableGrantAccess?: boolean;
+
+  /**
+   * Base URL for Dynamics 365 environment.
+   * Used for all API calls to Dynamics (accounts, contacts, appointments, grantAccess).
+   * @example "https://org.crm4.dynamics.com"
+   */
+  baseUrl: string;
 }
 
 export interface OrchestratorStepResult {

--- a/apps/sm-crm-fn/_shared/types/dynamics.ts
+++ b/apps/sm-crm-fn/_shared/types/dynamics.ts
@@ -50,6 +50,10 @@ export interface Appointment {
   statuscode?: number;
   /** Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365 */
   pgp_oggettodelcontatto?: number;
+  /** Categoria appuntamento (campo standard Dynamics) */
+  category?: string;
+  /** Data ordinamento - prossimo contatto previsto (campo standard Dynamics) */
+  sortdate?: string;
 }
 
 // -----------------------------------------------------------------------------
@@ -75,6 +79,10 @@ export interface CreateAppointmentRequest {
   statuscode?: number;
   /** Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365 */
   pgp_oggettodelcontatto?: number;
+  /** Categoria appuntamento (campo standard Dynamics) */
+  category?: string;
+  /** Data ordinamento - prossimo contatto previsto (campo standard Dynamics, DateTime) */
+  sortdate?: string;
   "ownerid@odata.bind"?: string;
   "regardingobjectid_account@odata.bind"?: string;
   appointment_activity_parties?: AppointmentParty[];
@@ -147,8 +155,12 @@ export interface CreateMeetingOrchestratorRequest {
   scheduledend: string;
   location?: string;
   description?: string;
-  /** Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365 */
+  /** Oggetto del contatto: valore Picklist (Edm.Int32) da Dynamics 365. Default suggerito: 100000005 (Integrazione Tecnica) */
   oggettoDelContatto?: number;
+  /** Categoria appuntamento (campo standard Dynamics) */
+  categoria?: string;
+  /** Data prossimo contatto previsto (campo standard Dynamics, formato ISO 8601) */
+  dataProssimoContatto?: string;
 
   // Opzioni
   dryRun?: boolean;

--- a/apps/sm-crm-fn/_shared/utils/config.ts
+++ b/apps/sm-crm-fn/_shared/utils/config.ts
@@ -24,6 +24,10 @@ const configSchema = z.object({
     .string()
     .min(1, "L'ambiente di esecuzione non puo essere una stringa vuota")
     .default("production"),
+  ENABLE_EMAIL_FORMAT_VALIDATION: z
+    .string()
+    .optional()
+    .transform((val) => val?.toLowerCase() === "true"),
 });
 
 export type AppConfig = z.infer<typeof configSchema>;
@@ -52,6 +56,7 @@ export function getConfigOrThrow(): AppConfig {
     DYNAMICS_URL_CONTACTS_UAT: process.env.DYNAMICS_URL_CONTACTS_UAT,
     DYNAMICS_SCOPE: process.env.DYNAMICS_SCOPE,
     NODE_ENV: process.env.NODE_ENV,
+    ENABLE_EMAIL_FORMAT_VALIDATION: process.env.ENABLE_EMAIL_FORMAT_VALIDATION,
   };
   try {
     return validateConfig(raw);

--- a/apps/sm-crm-fn/_shared/utils/config.ts
+++ b/apps/sm-crm-fn/_shared/utils/config.ts
@@ -8,7 +8,8 @@ const configSchema = z.object({
   DYNAMICS_BASE_URL_UAT: z
     .string()
     .url("DYNAMICS_BASE_URL_UAT deve essere un URL valido")
-    .min(1, "Il base URL UAT non puo essere una stringa vuota"),
+    .min(1, "Il base URL UAT non puo essere una stringa vuota")
+    .optional(),
   DYNAMICS_URL_CONTACTS: z
     .string()
     .url("DYNAMICS_URL_CONTACTS deve essere un URL valido")

--- a/apps/sm-crm-fn/_shared/utils/config.ts
+++ b/apps/sm-crm-fn/_shared/utils/config.ts
@@ -5,10 +5,19 @@ const configSchema = z.object({
     .string()
     .url("DYNAMICS_BASE_URL deve essere un URL valido")
     .min(1, "Il base URL non puo essere una stringa vuota"),
+  DYNAMICS_BASE_URL_UAT: z
+    .string()
+    .url("DYNAMICS_BASE_URL_UAT deve essere un URL valido")
+    .min(1, "Il base URL UAT non puo essere una stringa vuota"),
   DYNAMICS_URL_CONTACTS: z
     .string()
     .url("DYNAMICS_URL_CONTACTS deve essere un URL valido")
     .min(1, "L'URL Dynamics non puo essere una stringa vuota")
+    .optional(),
+  DYNAMICS_URL_CONTACTS_UAT: z
+    .string()
+    .url("DYNAMICS_URL_CONTACTS_UAT deve essere un URL valido")
+    .min(1, "L'URL Dynamics UAT non puo essere una stringa vuota")
     .optional(),
   DYNAMICS_SCOPE: z.string().min(1).optional(),
   NODE_ENV: z
@@ -38,7 +47,9 @@ export function validateConfig(config: unknown): AppConfig {
 export function getConfigOrThrow(): AppConfig {
   const raw = {
     DYNAMICS_BASE_URL: process.env.DYNAMICS_BASE_URL,
+    DYNAMICS_BASE_URL_UAT: process.env.DYNAMICS_BASE_URL_UAT,
     DYNAMICS_URL_CONTACTS: process.env.DYNAMICS_URL_CONTACTS,
+    DYNAMICS_URL_CONTACTS_UAT: process.env.DYNAMICS_URL_CONTACTS_UAT,
     DYNAMICS_SCOPE: process.env.DYNAMICS_SCOPE,
     NODE_ENV: process.env.NODE_ENV,
   };

--- a/apps/sm-crm-fn/_shared/utils/mappings.ts
+++ b/apps/sm-crm-fn/_shared/utils/mappings.ts
@@ -8,7 +8,7 @@
 // SICUREZZA:
 // - NON esporre questi dati pubblicamente
 // - Considerare lo spostamento in Azure Key Vault per produzione
-// - I GUID sono specifici per ogni ambiente Dynamics (DEV/UAT/PROD)
+// - I GUID sono specifici per ogni ambiente Dynamics (UAT/PROD)
 // - Accesso limitato solo a personale autorizzato
 //
 // =============================================================================
@@ -27,28 +27,17 @@ export const PRODUCTS_MAP: Record<
   Environment,
   Record<ProductIdSelfcare, string>
 > = {
-  DEV: {
-    "prod-pn": "617cbe1b-bb58-f011-877b-000d3a662132",
-    "prod-io": "26a975ef-a205-f011-bae4-000d3ab7023d",
-    "prod-pagopa": "c00c3e9a-a205-f011-bae3-000d3adf9667",
-    "prod-idpay": "04c4d12b-a205-f011-bae3-000d3adf9667",
-    "prod-idpay-merchant": "637cbe1b-bb58-f011-877b-000d3a662132",
-    "prod-checkiban": "22a975ef-a205-f011-bae4-000d3ab7023d",
-    "prod-interop": "24a975ef-a205-f011-bae4-000d3ab7023d",
-    "prod-io-premium": "46af0f1c-bb58-f011-877b-6045bdde77c4",
-    "prod-io-sign": "ca089f05-bd58-f011-877b-6045bdde7236",
-    "prod-rtp": "dde9d520-5f11-f011-998b-000d3adf9667",
-  },
+  // NOTA: UAT usa GUID specifici per l'ambiente di test
   UAT: {
     "prod-pn": "617cbe1b-bb58-f011-877b-000d3a662132",
-    "prod-io": "26a975ef-a205-f011-bae4-000d3ab7023d",
-    "prod-pagopa": "c00c3e9a-a205-f011-bae3-000d3adf9667",
-    "prod-idpay": "04c4d12b-a205-f011-bae3-000d3adf9667",
     "prod-idpay-merchant": "637cbe1b-bb58-f011-877b-000d3a662132",
     "prod-checkiban": "22a975ef-a205-f011-bae4-000d3ab7023d",
     "prod-interop": "24a975ef-a205-f011-bae4-000d3ab7023d",
-    "prod-io-premium": "46af0f1c-bb58-f011-877b-6045bdde77c4",
+    "prod-io": "26a975ef-a205-f011-bae4-000d3ab7023d",
+    "prod-idpay": "04c4d12b-a205-f011-bae3-000d3adf9667",
+    "prod-pagopa": "c00c3e9a-a205-f011-bae3-000d3adf9667",
     "prod-io-sign": "ca089f05-bd58-f011-877b-6045bdde7236",
+    "prod-io-premium": "46af0f1c-bb58-f011-877b-6045bdde77c4",
     "prod-rtp": "dde9d520-5f11-f011-998b-000d3adf9667",
   },
   PROD: {
@@ -87,7 +76,6 @@ export const TIPOLOGIA_REFERENTE_MAP: Record<TipologiaReferente, number> = {
 // -----------------------------------------------------------------------------
 
 export const TEAMS_MAP: Record<Environment, string> = {
-  DEV: "5f9c165c-1e7d-ef11-ac20-000d3ad807dc",
   UAT: "5f9c165c-1e7d-ef11-ac20-000d3ad807dc",
   PROD: "5f9c165c-1e7d-ef11-ac20-000d3ad807dc",
 };
@@ -97,7 +85,6 @@ export const TEAMS_MAP: Record<Environment, string> = {
 // -----------------------------------------------------------------------------
 
 export const BASE_URLS: Record<Environment, string> = {
-  DEV: "https://dev-pagopa.crm4.dynamics.com",
   UAT: "https://uat-pagopa.crm4.dynamics.com",
   PROD: "https://pagopa.crm4.dynamics.com",
 };
@@ -133,8 +120,6 @@ export function getBaseUrl(environment: Environment): string {
 }
 
 export function resolveEnvironment(baseUrl: string): Environment {
-  if (baseUrl.includes("dev-pagopa")) return "DEV";
   if (baseUrl.includes("uat-pagopa")) return "UAT";
-  if (baseUrl.includes("pagopa.crm4")) return "PROD";
-  return "UAT"; // Default
+  return "PROD"; // Default a PROD
 }

--- a/apps/sm-crm-fn/_shared/utils/mappings.ts
+++ b/apps/sm-crm-fn/_shared/utils/mappings.ts
@@ -71,6 +71,20 @@ export const TIPOLOGIA_REFERENTE_MAP: Record<TipologiaReferente, number> = {
   REFERENTE_BUSINESS_APICALE_ACCOUNT: 100000008,
 };
 
+/**
+ * Mapping placeholder per i valori della Picklist pgp_oggettodelcontatto su appointment.
+ * I valori interi reali devono essere recuperati tramite il probe diagnostics (/api/diagnostics)
+ * chiamando l'endpoint con il campo oggettoDelContattoPicklist nella risposta.
+ *
+ * @example
+ * // Chiamare GET /api/diagnostics?accountId=... con header x-dynamics-environment: UAT
+ * // e leggere oggettoDelContattoPicklist.options per i valori reali
+ */
+export const OGGETTO_DEL_CONTATTO_MAP: Record<string, number> = {
+  // TODO: popolare con i valori reali una volta eseguito il probe diagnostics in UAT
+  // es. 'post-vendita': 100000000,
+};
+
 // -----------------------------------------------------------------------------
 // Mapping Team per GrantAccess
 // -----------------------------------------------------------------------------

--- a/apps/sm-crm-fn/_shared/utils/mappings.ts
+++ b/apps/sm-crm-fn/_shared/utils/mappings.ts
@@ -72,18 +72,25 @@ export const TIPOLOGIA_REFERENTE_MAP: Record<TipologiaReferente, number> = {
 };
 
 /**
- * Mapping placeholder per i valori della Picklist pgp_oggettodelcontatto su appointment.
- * I valori interi reali devono essere recuperati tramite il probe diagnostics (/api/diagnostics)
- * chiamando l'endpoint con il campo oggettoDelContattoPicklist nella risposta.
+ * Mapping dei valori della Picklist pgp_oggettodelcontatto su appointment.
  *
- * @example
- * // Chiamare GET /api/diagnostics?accountId=... con header x-dynamics-environment: UAT
- * // e leggere oggettoDelContattoPicklist.options per i valori reali
+ * Valori forniti dal team Dynamics - identici in UAT e PROD.
+ *
+ * @default 100000005 (Integrazione Tecnica) - valore suggerito per il caso d'uso corrente
  */
 export const OGGETTO_DEL_CONTATTO_MAP: Record<string, number> = {
-  // TODO: popolare con i valori reali una volta eseguito il probe diagnostics in UAT
-  // es. 'post-vendita': 100000000,
+  opportunita: 100000000,
+  "post-vendita": 100000001,
+  informativa: 100000002,
+  comunicazione: 100000003,
+  "pre-sales": 100000004,
+  "integrazione-tecnica": 100000005, // Default suggerito
 };
+
+/**
+ * Tipo per i valori validi di oggettoDelContatto
+ */
+export type OggettoDelContatto = keyof typeof OGGETTO_DEL_CONTATTO_MAP;
 
 // -----------------------------------------------------------------------------
 // Mapping Team per GrantAccess

--- a/apps/sm-crm-fn/_shared/utils/requestEnvironment.ts
+++ b/apps/sm-crm-fn/_shared/utils/requestEnvironment.ts
@@ -13,18 +13,42 @@ export type DynamicsEnvironment = "UAT" | "PROD";
 export const DYNAMICS_ENVIRONMENT_HEADER = "x-dynamics-environment";
 
 /**
+ * Custom error thrown when an invalid Dynamics environment header value is provided.
+ */
+export class InvalidDynamicsEnvironmentError extends Error {
+  constructor(
+    public readonly headerName: string,
+    public readonly headerValue: string,
+  ) {
+    super(
+      `Invalid ${headerName} header value: "${headerValue}". Must be "UAT" or "PROD".`,
+    );
+    this.name = "InvalidDynamicsEnvironmentError";
+  }
+}
+
+/**
+ * Type guard to check if an error is an InvalidDynamicsEnvironmentError.
+ */
+export function isInvalidDynamicsEnvironmentError(
+  error: unknown,
+): error is InvalidDynamicsEnvironmentError {
+  return error instanceof InvalidDynamicsEnvironmentError;
+}
+
+/**
  * Resolves the target Dynamics environment from the request header.
  *
  * @param request - Azure Functions HTTP request object
  * @returns The resolved environment type ("UAT" or "PROD")
- * @throws Error if the header value is invalid (not "UAT" or "PROD")
+ * @throws InvalidDynamicsEnvironmentError if the header value is invalid (not "UAT" or "PROD")
  *
  * @example
  * ```typescript
  * const env = resolveDynamicsEnvironment(request);
  * // Returns "UAT" if header is "uat", "UAT", etc.
  * // Returns "PROD" if header is "prod", "PROD", missing, etc.
- * // Throws error if header is "invalid"
+ * // Throws InvalidDynamicsEnvironmentError if header is "invalid"
  * ```
  */
 export function resolveDynamicsEnvironment(
@@ -43,8 +67,9 @@ export function resolveDynamicsEnvironment(
     return normalized as DynamicsEnvironment;
   }
 
-  throw new Error(
-    `Invalid ${DYNAMICS_ENVIRONMENT_HEADER} header value: "${headerValue}". Must be "UAT" or "PROD".`,
+  throw new InvalidDynamicsEnvironmentError(
+    DYNAMICS_ENVIRONMENT_HEADER,
+    headerValue,
   );
 }
 

--- a/apps/sm-crm-fn/_shared/utils/requestEnvironment.ts
+++ b/apps/sm-crm-fn/_shared/utils/requestEnvironment.ts
@@ -1,0 +1,106 @@
+import { HttpRequest } from "@azure/functions";
+
+/**
+ * Supported Dynamics 365 environment types.
+ * Used to route requests to different Dynamics instances.
+ */
+export type DynamicsEnvironment = "UAT" | "PROD";
+
+/**
+ * Header name for specifying the target Dynamics environment.
+ * Expected values: "UAT" or "PROD" (case-insensitive).
+ */
+export const DYNAMICS_ENVIRONMENT_HEADER = "x-dynamics-environment";
+
+/**
+ * Resolves the target Dynamics environment from the request header.
+ *
+ * @param request - Azure Functions HTTP request object
+ * @returns The resolved environment type ("UAT" or "PROD")
+ * @throws Error if the header value is invalid (not "UAT" or "PROD")
+ *
+ * @example
+ * ```typescript
+ * const env = resolveDynamicsEnvironment(request);
+ * // Returns "UAT" if header is "uat", "UAT", etc.
+ * // Returns "PROD" if header is "prod", "PROD", missing, etc.
+ * // Throws error if header is "invalid"
+ * ```
+ */
+export function resolveDynamicsEnvironment(
+  request: HttpRequest,
+): DynamicsEnvironment {
+  const headerValue = request.headers.get(DYNAMICS_ENVIRONMENT_HEADER);
+
+  // Default to PROD if header is not present (backward compatibility)
+  if (!headerValue) {
+    return "PROD";
+  }
+
+  const normalized = headerValue.trim().toUpperCase();
+
+  if (normalized === "UAT" || normalized === "PROD") {
+    return normalized as DynamicsEnvironment;
+  }
+
+  throw new Error(
+    `Invalid ${DYNAMICS_ENVIRONMENT_HEADER} header value: "${headerValue}". Must be "UAT" or "PROD".`,
+  );
+}
+
+/**
+ * Gets the appropriate Dynamics base URL for the specified environment.
+ *
+ * @param environment - Target Dynamics environment ("UAT" or "PROD")
+ * @returns The base URL for the specified environment
+ * @throws Error if the required environment variable is not set
+ *
+ * @example
+ * ```typescript
+ * const baseUrl = getDynamicsBaseUrl("UAT");
+ * // Returns value of DYNAMICS_BASE_URL_UAT
+ *
+ * const baseUrl = getDynamicsBaseUrl("PROD");
+ * // Returns value of DYNAMICS_BASE_URL
+ * ```
+ */
+export function getDynamicsBaseUrl(environment: DynamicsEnvironment): string {
+  const envVar =
+    environment === "UAT" ? "DYNAMICS_BASE_URL_UAT" : "DYNAMICS_BASE_URL";
+
+  const url = process.env[envVar];
+
+  if (!url) {
+    throw new Error(
+      `Environment variable ${envVar} is not set for ${environment} environment`,
+    );
+  }
+
+  return url;
+}
+
+/**
+ * Gets the appropriate Dynamics contacts URL for the specified environment.
+ *
+ * @param environment - Target Dynamics environment ("UAT" or "PROD")
+ * @returns The contacts URL for the specified environment, or undefined if not set
+ *
+ * @example
+ * ```typescript
+ * const contactsUrl = getDynamicsContactsUrl("UAT");
+ * // Returns value of DYNAMICS_URL_CONTACTS_UAT if set, otherwise undefined
+ *
+ * const contactsUrl = getDynamicsContactsUrl("PROD");
+ * // Returns value of DYNAMICS_URL_CONTACTS if set, otherwise undefined
+ * ```
+ */
+export function getDynamicsContactsUrl(
+  environment: DynamicsEnvironment,
+): string | undefined {
+  const envVar =
+    environment === "UAT"
+      ? "DYNAMICS_URL_CONTACTS_UAT"
+      : "DYNAMICS_URL_CONTACTS";
+
+  return process.env[envVar];
+}

--- a/apps/sm-crm-fn/accounts/handler.ts
+++ b/apps/sm-crm-fn/accounts/handler.ts
@@ -11,6 +11,10 @@ import {
   getAccountBySelfcareId,
   getAccountByName,
 } from "../_shared/services/accounts";
+import {
+  resolveDynamicsEnvironment,
+  getDynamicsBaseUrl,
+} from "../_shared/utils/requestEnvironment";
 
 /**
  * Handler per GET /api/v1/accounts
@@ -30,6 +34,10 @@ export async function getAccountHandler(
   context.log("HTTP trigger function processed a request: GET /accounts");
 
   try {
+    // Resolve Dynamics environment from header
+    const environment = resolveDynamicsEnvironment(request);
+    const baseUrl = getDynamicsBaseUrl(environment);
+
     const selfcareId = request.query.get("selfcareId");
     const name = request.query.get("name");
 
@@ -49,7 +57,7 @@ export async function getAccountHandler(
     // Ricerca per Selfcare ID (priorità)
     if (selfcareId) {
       context.log(`Ricerca account per Selfcare ID: ${selfcareId}`);
-      const account = await getAccountBySelfcareId(selfcareId);
+      const account = await getAccountBySelfcareId(selfcareId, baseUrl);
 
       if (!account) {
         return {
@@ -75,7 +83,7 @@ export async function getAccountHandler(
     // Ricerca per nome (fallback)
     if (name) {
       context.log(`Ricerca account per nome: ${name}`);
-      const account = await getAccountByName(name);
+      const account = await getAccountByName(name, baseUrl);
 
       if (!account) {
         return {
@@ -110,6 +118,18 @@ export async function getAccountHandler(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     context.error("Errore durante la ricerca account:", error);
+
+    // Check for environment resolution errors
+    if (errorMessage.includes("x-dynamics-environment")) {
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: errorMessage,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
 
     // Se è un errore di ambiguità, ritorna 409
     if (errorMessage.includes("Ambiguità")) {

--- a/apps/sm-crm-fn/accounts/handler.ts
+++ b/apps/sm-crm-fn/accounts/handler.ts
@@ -14,6 +14,7 @@ import {
 import {
   resolveDynamicsEnvironment,
   getDynamicsBaseUrl,
+  isInvalidDynamicsEnvironmentError,
 } from "../_shared/utils/requestEnvironment";
 
 /**
@@ -116,20 +117,21 @@ export async function getAccountHandler(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
     context.error("Errore durante la ricerca account:", error);
 
     // Check for environment resolution errors
-    if (errorMessage.includes("x-dynamics-environment")) {
+    if (isInvalidDynamicsEnvironmentError(error)) {
       return {
         status: 400,
         jsonBody: {
           success: false,
-          message: errorMessage,
+          message: error.message,
           timestamp: new Date().toISOString(),
         },
       };
     }
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
 
     // Se è un errore di ambiguità, ritorna 409
     if (errorMessage.includes("Ambiguità")) {

--- a/apps/sm-crm-fn/contacts/createHandler.ts
+++ b/apps/sm-crm-fn/contacts/createHandler.ts
@@ -17,6 +17,7 @@ import type {
 import {
   resolveDynamicsEnvironment,
   getDynamicsBaseUrl,
+  isInvalidDynamicsEnvironmentError,
 } from "../_shared/utils/requestEnvironment";
 
 interface CreateContactsRequestBody {
@@ -165,21 +166,21 @@ export async function createContactsHandler(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error("Unexpected error in createContactsHandler", error);
 
     // Check for environment resolution errors
-    if (errorMessage.includes("x-dynamics-environment")) {
+    if (isInvalidDynamicsEnvironmentError(error)) {
       return {
         status: 400,
         jsonBody: {
           success: false,
-          message: errorMessage,
+          message: error.message,
           timestamp: new Date().toISOString(),
         },
       };
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       status: 500,
       jsonBody: {

--- a/apps/sm-crm-fn/contacts/createHandler.ts
+++ b/apps/sm-crm-fn/contacts/createHandler.ts
@@ -14,6 +14,10 @@ import type {
   ProductIdSelfcare,
   TipologiaReferente,
 } from "../_shared/types/dynamics";
+import {
+  resolveDynamicsEnvironment,
+  getDynamicsBaseUrl,
+} from "../_shared/utils/requestEnvironment";
 
 interface CreateContactsRequestBody {
   institutionIdSelfcare: string;
@@ -50,108 +54,140 @@ export async function createContactsHandler(
   const logger = createLogger(context);
   logger.info("HTTP POST /contacts request received");
 
-  let body: unknown;
   try {
-    body = await request.json();
-  } catch {
-    return {
-      status: 400,
-      jsonBody: {
-        success: false,
-        message: "Body non valido: JSON malformato",
-        timestamp: new Date().toISOString(),
-      },
-    };
-  }
+    // Resolve Dynamics environment from header
+    const environment = resolveDynamicsEnvironment(request);
+    const baseUrl = getDynamicsBaseUrl(environment);
 
-  if (!isValidBody(body)) {
-    return {
-      status: 400,
-      jsonBody: {
-        success: false,
-        message:
-          "Parametri mancanti: institutionIdSelfcare, productIdSelfcare e partecipanti (con email, nome, cognome) sono obbligatori",
-        timestamp: new Date().toISOString(),
-      },
-    };
-  }
-
-  // Step 1: verifica account
-  const accountResult = await verifyAccount({
-    institutionIdSelfcare: body.institutionIdSelfcare,
-    enableFallback: false,
-  });
-
-  if (!accountResult.found || !accountResult.account) {
-    return {
-      status: 404,
-      jsonBody: {
-        success: false,
-        message: accountResult.error ?? "Ente non trovato",
-        timestamp: new Date().toISOString(),
-      },
-    };
-  }
-
-  const accountId = accountResult.account.accountid;
-
-  // Step 2: crea ogni contatto
-  const results: Array<{
-    email: string;
-    success: boolean;
-    contactId?: string;
-    error?: string;
-  }> = [];
-
-  for (const partecipante of body.partecipanti) {
+    let body: unknown;
     try {
-      const contact = await createContact({
-        firstname: partecipante.nome,
-        lastname: partecipante.cognome,
-        email: partecipante.email,
-        productIdSelfcare: body.productIdSelfcare,
-        tipologiaReferente: partecipante.tipologiaReferente ?? "TECNICO",
-        accountId,
-      });
-
-      results.push({
-        email: partecipante.email,
-        success: true,
-        contactId: contact.contactid,
-      });
-
-      logger.info("Contact created", {
-        email: partecipante.email,
-        contactId: contact.contactid,
-      });
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      results.push({
-        email: partecipante.email,
-        success: false,
-        error: errorMessage,
-      });
-      logger.warn("Contact creation failed", {
-        email: partecipante.email,
-        error: errorMessage,
-      });
+      body = await request.json();
+    } catch {
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: "Body non valido: JSON malformato",
+          timestamp: new Date().toISOString(),
+        },
+      };
     }
+
+    if (!isValidBody(body)) {
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message:
+            "Parametri mancanti: institutionIdSelfcare, productIdSelfcare e partecipanti (con email, nome, cognome) sono obbligatori",
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
+
+    // Step 1: verifica account
+    const accountResult = await verifyAccount({
+      institutionIdSelfcare: body.institutionIdSelfcare,
+      enableFallback: false,
+      baseUrl,
+    });
+
+    if (!accountResult.found || !accountResult.account) {
+      return {
+        status: 404,
+        jsonBody: {
+          success: false,
+          message: accountResult.error ?? "Ente non trovato",
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
+
+    const accountId = accountResult.account.accountid;
+
+    // Step 2: crea ogni contatto
+    const results: Array<{
+      email: string;
+      success: boolean;
+      contactId?: string;
+      error?: string;
+    }> = [];
+
+    for (const partecipante of body.partecipanti) {
+      try {
+        const contact = await createContact(baseUrl, {
+          firstname: partecipante.nome,
+          lastname: partecipante.cognome,
+          email: partecipante.email,
+          productIdSelfcare: body.productIdSelfcare,
+          tipologiaReferente: partecipante.tipologiaReferente ?? "TECNICO",
+          accountId,
+        });
+
+        results.push({
+          email: partecipante.email,
+          success: true,
+          contactId: contact.contactid,
+        });
+
+        logger.info("Contact created", {
+          email: partecipante.email,
+          contactId: contact.contactid,
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        results.push({
+          email: partecipante.email,
+          success: false,
+          error: errorMessage,
+        });
+        logger.warn("Contact creation failed", {
+          email: partecipante.email,
+          error: errorMessage,
+        });
+      }
+    }
+
+    const successCount = results.filter((r) => r.success).length;
+    const allFailed = successCount === 0;
+    const partialSuccess = successCount > 0 && successCount < results.length;
+
+    return {
+      status: allFailed ? 500 : partialSuccess ? 207 : 201,
+      jsonBody: {
+        success: !allFailed,
+        accountId,
+        results,
+        created: successCount,
+        total: results.length,
+        timestamp: new Date().toISOString(),
+      },
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error("Unexpected error in createContactsHandler", error);
+
+    // Check for environment resolution errors
+    if (errorMessage.includes("x-dynamics-environment")) {
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: errorMessage,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
+
+    return {
+      status: 500,
+      jsonBody: {
+        success: false,
+        message: "Errore durante la creazione dei contatti",
+        error: errorMessage,
+        timestamp: new Date().toISOString(),
+      },
+    };
   }
-
-  const successCount = results.filter((r) => r.success).length;
-  const allFailed = successCount === 0;
-  const partialSuccess = successCount > 0 && successCount < results.length;
-
-  return {
-    status: allFailed ? 500 : partialSuccess ? 207 : 201,
-    jsonBody: {
-      success: !allFailed,
-      accountId,
-      results,
-      created: successCount,
-      total: results.length,
-      timestamp: new Date().toISOString(),
-    },
-  };
 }

--- a/apps/sm-crm-fn/contacts/handler.ts
+++ b/apps/sm-crm-fn/contacts/handler.ts
@@ -12,6 +12,10 @@ import {
   getContactById,
 } from "../_shared/services/contacts";
 import { createLogger } from "../_shared/utils/logger";
+import {
+  resolveDynamicsEnvironment,
+  getDynamicsBaseUrl,
+} from "../_shared/utils/requestEnvironment";
 
 /**
  * Handler per GET /api/v1/contacts
@@ -32,6 +36,10 @@ export async function getContactsHandler(
   logger.info("HTTP GET /contacts request received");
 
   try {
+    // Resolve Dynamics environment from header
+    const environment = resolveDynamicsEnvironment(request);
+    const baseUrl = getDynamicsBaseUrl(environment);
+
     const accountId = request.query.get("accountId");
     const contactId = request.query.get("contactId");
 
@@ -79,7 +87,7 @@ export async function getContactsHandler(
     // Ricerca per Contact ID (singolo contatto)
     if (contactId) {
       logger.info("Searching contact by ID", { contactId });
-      const contact = await getContactById(contactId);
+      const contact = await getContactById(baseUrl, contactId);
 
       if (!contact) {
         logger.warn("Contact not found", { contactId });
@@ -112,7 +120,7 @@ export async function getContactsHandler(
     // Ricerca per Account ID (lista contatti dell'ente)
     if (accountId) {
       logger.info("Searching contacts by Account ID", { accountId });
-      const result = await getContactsByAccountId(accountId);
+      const result = await getContactsByAccountId(baseUrl, accountId);
 
       const count = result.value?.length ?? 0;
 
@@ -149,6 +157,18 @@ export async function getContactsHandler(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error("Unexpected error in getContactsHandler", error);
+
+    // Check for environment resolution errors
+    if (errorMessage.includes("x-dynamics-environment")) {
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: errorMessage,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
 
     return {
       status: 500,

--- a/apps/sm-crm-fn/contacts/handler.ts
+++ b/apps/sm-crm-fn/contacts/handler.ts
@@ -15,6 +15,7 @@ import { createLogger } from "../_shared/utils/logger";
 import {
   resolveDynamicsEnvironment,
   getDynamicsBaseUrl,
+  isInvalidDynamicsEnvironmentError,
 } from "../_shared/utils/requestEnvironment";
 
 /**
@@ -155,21 +156,21 @@ export async function getContactsHandler(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error("Unexpected error in getContactsHandler", error);
 
     // Check for environment resolution errors
-    if (errorMessage.includes("x-dynamics-environment")) {
+    if (isInvalidDynamicsEnvironmentError(error)) {
       return {
         status: 400,
         jsonBody: {
           success: false,
-          message: errorMessage,
+          message: error.message,
           timestamp: new Date().toISOString(),
         },
       };
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       status: 500,
       jsonBody: {

--- a/apps/sm-crm-fn/diagnostics/handler.ts
+++ b/apps/sm-crm-fn/diagnostics/handler.ts
@@ -3,7 +3,6 @@ import type {
   HttpResponseInit,
   InvocationContext,
 } from "@azure/functions";
-import { getConfigOrThrow } from "../_shared/utils/config";
 import { resolveEnvironment, PRODUCTS_MAP } from "../_shared/utils/mappings";
 import { get, buildUrl } from "../_shared/services/httpClient";
 import { createLogger } from "../_shared/utils/logger";
@@ -29,7 +28,11 @@ async function probeMetadata(baseUrl: string): Promise<{
   try {
     const data = await get<Record<string, unknown>>(url, baseUrl);
     const pgpEntities = (data.value ?? [])
-      .filter((e) => (e["LogicalName"] as string)?.startsWith("pgp_"))
+      .filter(
+        (e) =>
+          typeof e["LogicalName"] === "string" &&
+          (e["LogicalName"] as string).startsWith("pgp_"),
+      )
       .map((e) => ({
         logicalName: e["LogicalName"] as string,
         entitySetName: e["EntitySetName"] as string,
@@ -74,6 +77,174 @@ async function probeContactProductRelationship(baseUrl: string): Promise<{
     const errorMessage = error instanceof Error ? error.message : String(error);
     return { relationships: [], error: errorMessage };
   }
+}
+
+/**
+ * Risultato della validazione di un singolo campo su Dynamics 365.
+ */
+interface FieldValidationEntry {
+  logicalName: string;
+  attributeType: string;
+  expected: boolean;
+  found: boolean;
+  /** Se true, il campo è un navigation property e non compare tra gli Attributes standard */
+  isNavigationProperty?: boolean;
+}
+
+/**
+ * Risultato complessivo della validazione dei campi di un'entità Dynamics 365.
+ */
+interface EntityFieldProbeResult {
+  entity: string;
+  fields: FieldValidationEntry[];
+  /** Campi attesi ma non trovati tra gli Attributes di Dynamics (esclusi i navigation property) */
+  missing: string[];
+  /** Navigation property dichiarati esplicitamente: non vengono inclusi in missing */
+  navigationProperties: string[];
+  error: string | null;
+}
+
+/**
+ * Verifica l'esistenza dei campi (Attributes) di una specifica entità in Dynamics 365
+ * tramite l'API OData dei metadati.
+ *
+ * I navigation property (es. lookup come `pgp_Prodottoid`) non compaiono tra gli Attributes
+ * standard: devono essere dichiarati esplicitamente tramite il parametro `navigationPropertyFields`
+ * e vengono esclusi dal conteggio dei campi mancanti.
+ *
+ * @param baseUrl - URL base dell'ambiente Dynamics (es. https://org.crm4.dynamics.com)
+ * @param entityLogicalName - Nome logico dell'entità da interrogare (es. 'appointment', 'contact')
+ * @param expectedFields - Lista dei nomi logici dei campi standard attesi
+ * @param navigationPropertyFields - Lista dei navigation property da segnalare separatamente
+ * @returns Oggetto contenente l'elenco dei campi con flag expected/found, la lista dei missing e dei navigation property
+ */
+async function probeEntityFields(
+  baseUrl: string,
+  entityLogicalName: string,
+  expectedFields: string[],
+  navigationPropertyFields: string[] = [],
+): Promise<EntityFieldProbeResult> {
+  const url = buildUrl({
+    baseUrl,
+    endpoint: `/api/data/v9.2/EntityDefinitions(LogicalName='${entityLogicalName}')/Attributes`,
+    select: "LogicalName,AttributeType",
+  });
+
+  try {
+    const data = await get<Record<string, unknown>>(url, baseUrl);
+    const attributes = data.value ?? [];
+
+    // Costruisce la mappa case-insensitive dei campi trovati (solo quelli con LogicalName valido)
+    const foundFieldsMap = new Map<string, string>();
+    for (const attr of attributes) {
+      const logicalName = attr["LogicalName"];
+      const attributeType = attr["AttributeType"];
+      if (
+        typeof logicalName === "string" &&
+        typeof attributeType === "string"
+      ) {
+        foundFieldsMap.set(logicalName.toLowerCase(), attributeType);
+      }
+    }
+
+    // Costruisce l'elenco dei campi trovati con flag expected/found
+    const fields: FieldValidationEntry[] = [];
+    for (const attr of attributes) {
+      const logicalName = attr["LogicalName"];
+      const attributeType = attr["AttributeType"];
+      if (typeof logicalName !== "string" || typeof attributeType !== "string")
+        continue;
+
+      const isExpected = expectedFields.some(
+        (exp) => exp.toLowerCase() === logicalName.toLowerCase(),
+      );
+      if (isExpected) {
+        fields.push({
+          logicalName,
+          attributeType,
+          expected: true,
+          found: true,
+        });
+      }
+    }
+
+    // Aggiunge i campi attesi ma non trovati (missing)
+    const missing = expectedFields.filter(
+      (exp) => !foundFieldsMap.has(exp.toLowerCase()),
+    );
+
+    // I navigation property vengono segnalati separatamente, non come missing
+    const navigationProperties = navigationPropertyFields;
+
+    return {
+      entity: entityLogicalName,
+      fields,
+      missing,
+      navigationProperties,
+      error: null,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      entity: entityLogicalName,
+      fields: [],
+      missing: expectedFields,
+      navigationProperties: navigationPropertyFields,
+      error: errorMessage,
+    };
+  }
+}
+
+/**
+ * Esegue in parallelo la validazione dei campi per le entità `appointment` e `contact`,
+ * verificando l'esistenza di tutti i campi custom e standard utilizzati dall'applicazione.
+ *
+ * @param baseUrl - URL base dell'ambiente Dynamics
+ * @returns Oggetto consolidato con i risultati di validazione per entrambe le entità
+ */
+async function probeFieldValidation(baseUrl: string): Promise<{
+  appointment: EntityFieldProbeResult;
+  contact: EntityFieldProbeResult;
+}> {
+  // Campi standard attesi per l'entità appointment
+  const appointmentExpectedFields = [
+    "pgp_oggettodelcontatto",
+    "nextstep",
+    "new_dataprossimocontatto",
+    "subject",
+    "scheduledstart",
+    "scheduledend",
+    "location",
+    "description",
+    "statuscode",
+    "statecode",
+  ];
+
+  // Campi standard attesi per l'entità contact
+  const contactExpectedFields = [
+    "emailaddress1",
+    "firstname",
+    "lastname",
+    "pgp_tipologiareferente",
+  ];
+
+  // Navigation property di contact: sono lookup/relation e non compaiono tra gli Attributes
+  const contactNavigationProperties = ["pgp_Prodottoid"];
+
+  const [appointmentResult, contactResult] = await Promise.all([
+    probeEntityFields(baseUrl, "appointment", appointmentExpectedFields),
+    probeEntityFields(
+      baseUrl,
+      "contact",
+      contactExpectedFields,
+      contactNavigationProperties,
+    ),
+  ]);
+
+  return {
+    appointment: appointmentResult,
+    contact: contactResult,
+  };
 }
 
 async function lookupAccount(
@@ -134,15 +305,17 @@ export async function probeDynamicsHandler(
     const contactProductRel = await probeContactProductRelationship(baseUrl);
     logger.info("Contact→Product relationships found", {
       count: contactProductRel.relationships.length,
+      error: contactProductRel.error,
     });
 
     // Step 2: lista tutte le entità pgp_ dai metadati di Dynamics
     const metadata = await probeMetadata(baseUrl);
     logger.info("Metadata probe result", {
       count: metadata.pgpEntities.length,
+      error: metadata.error,
     });
 
-    // Step 2: proba i candidati noti come fallback
+    // Step 2b: proba i candidati noti come fallback per la entity dei prodotti
     const candidates = ["pgp_prodotti", "pgp_products"] as const;
     const results: Record<string, CandidateResult> = {};
 
@@ -161,7 +334,7 @@ export async function probeDynamicsHandler(
           count: data.value?.length ?? 0,
           sample,
         };
-        logger.info(`Candidate probe succeeded`, { candidate });
+        logger.info("Candidate probe succeeded", { candidate });
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
@@ -174,7 +347,7 @@ export async function probeDynamicsHandler(
           statusCode,
           error: errorMessage,
         };
-        logger.warn(`Candidate probe failed`, { candidate, statusCode });
+        logger.warn("Candidate probe failed", { candidate, statusCode });
       }
     }
 
@@ -188,6 +361,17 @@ export async function probeDynamicsHandler(
       candidates.find((c) => results[c]?.success === true) ??
       null;
 
+    // Step 3: validazione dei campi per le entità appointment e contact
+    const fieldValidation = await probeFieldValidation(baseUrl);
+    logger.info("Field validation completed", {
+      appointmentMissing: fieldValidation.appointment.missing,
+      contactMissing: fieldValidation.contact.missing,
+      appointmentFoundCount: fieldValidation.appointment.fields.length,
+      contactFoundCount: fieldValidation.contact.fields.length,
+      appointmentError: fieldValidation.appointment.error,
+      contactError: fieldValidation.contact.error,
+    });
+
     logger.info("Diagnostics probe completed", { environment, recommendation });
 
     return {
@@ -198,6 +382,7 @@ export async function probeDynamicsHandler(
         ...(accountLookup !== undefined && { accountLookup }),
         contactProductRelationships: contactProductRel,
         metadata,
+        fieldValidation,
         recommendation,
         products: PRODUCTS_MAP[environment],
         candidates: results,

--- a/apps/sm-crm-fn/diagnostics/handler.ts
+++ b/apps/sm-crm-fn/diagnostics/handler.ts
@@ -7,22 +7,27 @@ import { getConfigOrThrow } from "../_shared/utils/config";
 import { resolveEnvironment, PRODUCTS_MAP } from "../_shared/utils/mappings";
 import { get, buildUrl } from "../_shared/services/httpClient";
 import { createLogger } from "../_shared/utils/logger";
+import {
+  resolveDynamicsEnvironment,
+  getDynamicsBaseUrl,
+} from "../_shared/utils/requestEnvironment";
 
 type CandidateResult =
   | { success: true; count: number; sample: Record<string, unknown> }
   | { success: false; statusCode: number | undefined; error: string };
 
-async function probeMetadata(): Promise<{
+async function probeMetadata(baseUrl: string): Promise<{
   pgpEntities: Array<{ logicalName: string; entitySetName: string }>;
   error: string | null;
 }> {
   const url = buildUrl({
+    baseUrl,
     endpoint: "/api/data/v9.2/EntityDefinitions",
     select: "LogicalName,EntitySetName",
   });
 
   try {
-    const data = await get<Record<string, unknown>>(url);
+    const data = await get<Record<string, unknown>>(url, baseUrl);
     const pgpEntities = (data.value ?? [])
       .filter((e) => (e["LogicalName"] as string)?.startsWith("pgp_"))
       .map((e) => ({
@@ -36,7 +41,7 @@ async function probeMetadata(): Promise<{
   }
 }
 
-async function probeContactProductRelationship(): Promise<{
+async function probeContactProductRelationship(baseUrl: string): Promise<{
   relationships: Array<{
     schemaName: string;
     referencingNavigationPropertyName: string;
@@ -46,6 +51,7 @@ async function probeContactProductRelationship(): Promise<{
 }> {
   // Cerca tutte le ManyToOne relationships del contact verso entità che contengono "product"
   const url = buildUrl({
+    baseUrl,
     endpoint:
       "/api/data/v9.2/EntityDefinitions(LogicalName='contact')/ManyToOneRelationships",
     select:
@@ -53,15 +59,14 @@ async function probeContactProductRelationship(): Promise<{
   });
 
   try {
-    const data = await get<Record<string, unknown>>(url);
+    const data = await get<Record<string, unknown>>(url, baseUrl);
     const relationships = (data.value ?? [])
-      .filter((r) =>
-        (r["ReferencedEntity"] as string)?.includes("product"),
-      )
+      .filter((r) => (r["ReferencedEntity"] as string)?.includes("product"))
       .map((r) => ({
         schemaName: r["SchemaName"] as string,
-        referencingNavigationPropertyName:
-          r["ReferencingEntityNavigationPropertyName"] as string,
+        referencingNavigationPropertyName: r[
+          "ReferencingEntityNavigationPropertyName"
+        ] as string,
         referencedEntity: r["ReferencedEntity"] as string,
       }));
     return { relationships, error: null };
@@ -71,23 +76,29 @@ async function probeContactProductRelationship(): Promise<{
   }
 }
 
-async function lookupAccount(accountId: string): Promise<{
+async function lookupAccount(
+  baseUrl: string,
+  accountId: string,
+): Promise<{
   accountid: string;
   name: string | null;
   pgp_identificativoselfcare: string | null;
 } | null> {
   const url = buildUrl({
+    baseUrl,
     endpoint: `/api/data/v9.2/accounts(${accountId})`,
     select: "accountid,name,pgp_identificativoselfcare",
   });
 
   try {
-    const data = await get<Record<string, unknown>>(url);
-    const account = data.value?.[0] ?? (data as unknown as Record<string, unknown>);
+    const data = await get<Record<string, unknown>>(url, baseUrl);
+    const account =
+      data.value?.[0] ?? (data as unknown as Record<string, unknown>);
     return {
       accountid: account["accountid"] as string,
       name: (account["name"] as string) ?? null,
-      pgp_identificativoselfcare: (account["pgp_identificativoselfcare"] as string) ?? null,
+      pgp_identificativoselfcare:
+        (account["pgp_identificativoselfcare"] as string) ?? null,
     };
   } catch {
     return null;
@@ -99,87 +110,121 @@ export async function probeDynamicsHandler(
   context: InvocationContext,
 ): Promise<HttpResponseInit> {
   const logger = createLogger(context);
-  const cfg = getConfigOrThrow();
-  const environment = resolveEnvironment(cfg.DYNAMICS_BASE_URL);
 
-  logger.info("Diagnostics probe started", { environment });
+  try {
+    // Resolve Dynamics environment from header
+    const environment = resolveDynamicsEnvironment(request);
+    const baseUrl = getDynamicsBaseUrl(environment);
 
-  // Lookup opzionale: ?accountId=<guid>
-  const accountIdParam = request.query.get("accountId");
-  let accountLookup: Awaited<ReturnType<typeof lookupAccount>> | undefined;
-  if (accountIdParam) {
-    accountLookup = await lookupAccount(accountIdParam) ?? undefined;
-    logger.info("Account lookup result", {
-      accountId: accountIdParam,
-      found: accountLookup != null,
-    });
-  }
+    logger.info("Diagnostics probe started", { environment });
 
-  // Step 1: relazioni ManyToOne del contact verso entità "product"
-  const contactProductRel = await probeContactProductRelationship();
-  logger.info("Contact→Product relationships found", {
-    count: contactProductRel.relationships.length,
-  });
-
-  // Step 2: lista tutte le entità pgp_ dai metadati di Dynamics
-  const metadata = await probeMetadata();
-  logger.info("Metadata probe result", { count: metadata.pgpEntities.length });
-
-  // Step 2: proba i candidati noti come fallback
-  const candidates = ["pgp_prodotti", "pgp_products"] as const;
-  const results: Record<string, CandidateResult> = {};
-
-  for (const candidate of candidates) {
-    const url = buildUrl({
-      endpoint: `/api/data/v9.2/${candidate}`,
-      top: "1",
-    });
-
-    try {
-      const data = await get<Record<string, unknown>>(url);
-      const sample = data.value?.[0] ?? {};
-      results[candidate] = {
-        success: true,
-        count: data.value?.length ?? 0,
-        sample,
-      };
-      logger.info(`Candidate probe succeeded`, { candidate });
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      const statusMatch = errorMessage.match(/failed: (\d+)/);
-      const statusCode = statusMatch ? parseInt(statusMatch[1], 10) : undefined;
-      results[candidate] = {
-        success: false,
-        statusCode,
-        error: errorMessage,
-      };
-      logger.warn(`Candidate probe failed`, { candidate, statusCode });
+    // Lookup opzionale: ?accountId=<guid>
+    const accountIdParam = request.query.get("accountId");
+    let accountLookup: Awaited<ReturnType<typeof lookupAccount>> | undefined;
+    if (accountIdParam) {
+      accountLookup =
+        (await lookupAccount(baseUrl, accountIdParam)) ?? undefined;
+      logger.info("Account lookup result", {
+        accountId: accountIdParam,
+        found: accountLookup != null,
+      });
     }
+
+    // Step 1: relazioni ManyToOne del contact verso entità "product"
+    const contactProductRel = await probeContactProductRelationship(baseUrl);
+    logger.info("Contact→Product relationships found", {
+      count: contactProductRel.relationships.length,
+    });
+
+    // Step 2: lista tutte le entità pgp_ dai metadati di Dynamics
+    const metadata = await probeMetadata(baseUrl);
+    logger.info("Metadata probe result", {
+      count: metadata.pgpEntities.length,
+    });
+
+    // Step 2: proba i candidati noti come fallback
+    const candidates = ["pgp_prodotti", "pgp_products"] as const;
+    const results: Record<string, CandidateResult> = {};
+
+    for (const candidate of candidates) {
+      const url = buildUrl({
+        baseUrl,
+        endpoint: `/api/data/v9.2/${candidate}`,
+        top: "1",
+      });
+
+      try {
+        const data = await get<Record<string, unknown>>(url, baseUrl);
+        const sample = data.value?.[0] ?? {};
+        results[candidate] = {
+          success: true,
+          count: data.value?.length ?? 0,
+          sample,
+        };
+        logger.info(`Candidate probe succeeded`, { candidate });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        const statusMatch = errorMessage.match(/failed: (\d+)/);
+        const statusCode = statusMatch
+          ? parseInt(statusMatch[1], 10)
+          : undefined;
+        results[candidate] = {
+          success: false,
+          statusCode,
+          error: errorMessage,
+        };
+        logger.warn(`Candidate probe failed`, { candidate, statusCode });
+      }
+    }
+
+    const prodottoEntity = metadata.pgpEntities.find(
+      (e) =>
+        e.logicalName.includes("prodotto") || e.logicalName.includes("product"),
+    );
+
+    const recommendation =
+      prodottoEntity?.entitySetName ??
+      candidates.find((c) => results[c]?.success === true) ??
+      null;
+
+    logger.info("Diagnostics probe completed", { environment, recommendation });
+
+    return {
+      status: 200,
+      jsonBody: {
+        environment,
+        dynamicsBaseUrl: baseUrl,
+        ...(accountLookup !== undefined && { accountLookup }),
+        contactProductRelationships: contactProductRel,
+        metadata,
+        recommendation,
+        products: PRODUCTS_MAP[environment],
+        candidates: results,
+      },
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error("Diagnostics probe failed", error);
+
+    // Check for environment resolution errors
+    if (errorMessage.includes("x-dynamics-environment")) {
+      return {
+        status: 400,
+        jsonBody: {
+          error: errorMessage,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
+
+    return {
+      status: 500,
+      jsonBody: {
+        error: "Diagnostics probe failed",
+        message: errorMessage,
+        timestamp: new Date().toISOString(),
+      },
+    };
   }
-
-  const prodottoEntity = metadata.pgpEntities.find((e) =>
-    e.logicalName.includes("prodotto") || e.logicalName.includes("product"),
-  );
-
-  const recommendation =
-    prodottoEntity?.entitySetName ??
-    candidates.find((c) => results[c]?.success === true) ??
-    null;
-
-  logger.info("Diagnostics probe completed", { environment, recommendation });
-
-  return {
-    status: 200,
-    jsonBody: {
-      environment,
-      dynamicsBaseUrl: cfg.DYNAMICS_BASE_URL,
-      ...(accountLookup !== undefined && { accountLookup }),
-      contactProductRelationships: contactProductRel,
-      metadata,
-      recommendation,
-      products: PRODUCTS_MAP[environment],
-      candidates: results,
-    },
-  };
 }

--- a/apps/sm-crm-fn/diagnostics/handler.ts
+++ b/apps/sm-crm-fn/diagnostics/handler.ts
@@ -209,8 +209,6 @@ async function probeFieldValidation(baseUrl: string): Promise<{
   // Campi standard attesi per l'entità appointment
   const appointmentExpectedFields = [
     "pgp_oggettodelcontatto",
-    "nextstep",
-    "new_dataprossimocontatto",
     "subject",
     "scheduledstart",
     "scheduledend",
@@ -273,6 +271,75 @@ async function lookupAccount(
     };
   } catch {
     return null;
+  }
+}
+
+/**
+ * Recupera i valori dell'OptionSet (Picklist) di un attributo specifico di un'entità Dynamics 365.
+ *
+ * Utilizza l'API dei metadati OData per ottenere i valori interi e le etichette
+ * associate alla picklist, necessari per mappare stringhe UI → valori Dynamics.
+ *
+ * @param baseUrl - URL base dell'ambiente Dynamics (es. https://org.crm4.dynamics.com)
+ * @param entityLogicalName - Nome logico dell'entità (es. 'appointment')
+ * @param attributeLogicalName - Nome logico dell'attributo Picklist (es. 'pgp_oggettodelcontatto')
+ * @returns Oggetto con i valori dell'OptionSet o un errore
+ */
+async function probePicklistValues(
+  baseUrl: string,
+  entityLogicalName: string,
+  attributeLogicalName: string,
+): Promise<{
+  options: Array<{ value: number; label: string }>;
+  error: string | null;
+}> {
+  const url = buildUrl({
+    baseUrl,
+    endpoint: `/api/data/v9.2/EntityDefinitions(LogicalName='${entityLogicalName}')/Attributes(LogicalName='${attributeLogicalName}')/Microsoft.Dynamics.CRM.PicklistAttributeMetadata`,
+    select: "OptionSet",
+  });
+
+  try {
+    const response = await get<Record<string, unknown>>(url, baseUrl);
+    // Per questo endpoint specifico, la risposta non ha 'value' ma i dati diretti
+    const data =
+      response.value?.[0] ?? (response as unknown as Record<string, unknown>);
+    const optionSet = data["OptionSet"] as Record<string, unknown> | undefined;
+    if (!optionSet) {
+      return {
+        options: [],
+        error:
+          "OptionSet non trovato nella risposta Dynamics — verificare che il campo sia di tipo Picklist",
+      };
+    }
+
+    const rawOptions = (optionSet["Options"] ?? []) as Array<
+      Record<string, unknown>
+    >;
+
+    const parsedOptions = rawOptions
+      .filter((opt) => typeof opt["Value"] === "number")
+      .map((opt) => {
+        const value = opt["Value"] as number;
+        const labelObj = opt["Label"] as Record<string, unknown> | undefined;
+        const localizedLabels = (labelObj?.["LocalizedLabels"] ?? []) as Array<
+          Record<string, unknown>
+        >;
+        // Cerca prima etichetta italiana (LanguageCode 1040), poi primo elemento disponibile
+        const italianLabel = localizedLabels.find(
+          (l) => l["LanguageCode"] === 1040,
+        );
+        const label =
+          ((italianLabel ?? localizedLabels[0])?.["Label"] as
+            | string
+            | undefined) ?? String(value);
+        return { value, label };
+      });
+
+    return { options: parsedOptions, error: null };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return { options: [], error: errorMessage };
   }
 }
 
@@ -372,6 +439,17 @@ export async function probeDynamicsHandler(
       contactError: fieldValidation.contact.error,
     });
 
+    // Step 4: valori Picklist di pgp_oggettodelcontatto su appointment
+    const oggettoDelContattoPicklist = await probePicklistValues(
+      baseUrl,
+      "appointment",
+      "pgp_oggettodelcontatto",
+    );
+    logger.info("Picklist pgp_oggettodelcontatto probe", {
+      optionCount: oggettoDelContattoPicklist.options.length,
+      error: oggettoDelContattoPicklist.error,
+    });
+
     logger.info("Diagnostics probe completed", { environment, recommendation });
 
     return {
@@ -383,6 +461,7 @@ export async function probeDynamicsHandler(
         contactProductRelationships: contactProductRel,
         metadata,
         fieldValidation,
+        oggettoDelContattoPicklist,
         recommendation,
         products: PRODUCTS_MAP[environment],
         candidates: results,

--- a/apps/sm-crm-fn/diagnostics/handler.ts
+++ b/apps/sm-crm-fn/diagnostics/handler.ts
@@ -209,6 +209,8 @@ async function probeFieldValidation(baseUrl: string): Promise<{
   // Campi standard attesi per l'entità appointment
   const appointmentExpectedFields = [
     "pgp_oggettodelcontatto",
+    "nextstep",
+    "new_dataprossimocontatto",
     "subject",
     "scheduledstart",
     "scheduledend",

--- a/apps/sm-crm-fn/diagnostics/handler.ts
+++ b/apps/sm-crm-fn/diagnostics/handler.ts
@@ -209,8 +209,8 @@ async function probeFieldValidation(baseUrl: string): Promise<{
   // Campi standard attesi per l'entità appointment
   const appointmentExpectedFields = [
     "pgp_oggettodelcontatto",
-    "nextstep",
-    "new_dataprossimocontatto",
+    "category",
+    "sortdate",
     "subject",
     "scheduledstart",
     "scheduledend",

--- a/apps/sm-crm-fn/diagnostics/handler.ts
+++ b/apps/sm-crm-fn/diagnostics/handler.ts
@@ -9,6 +9,7 @@ import { createLogger } from "../_shared/utils/logger";
 import {
   resolveDynamicsEnvironment,
   getDynamicsBaseUrl,
+  isInvalidDynamicsEnvironmentError,
 } from "../_shared/utils/requestEnvironment";
 
 type CandidateResult =
@@ -470,20 +471,20 @@ export async function probeDynamicsHandler(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error("Diagnostics probe failed", error);
 
     // Check for environment resolution errors
-    if (errorMessage.includes("x-dynamics-environment")) {
+    if (isInvalidDynamicsEnvironmentError(error)) {
       return {
         status: 400,
         jsonBody: {
-          error: errorMessage,
+          error: error.message,
           timestamp: new Date().toISOString(),
         },
       };
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       status: 500,
       jsonBody: {

--- a/apps/sm-crm-fn/docs/API_GUIDE.md
+++ b/apps/sm-crm-fn/docs/API_GUIDE.md
@@ -264,7 +264,7 @@ Products use string identifiers in Selfcare that must be mapped to Dynamics GUID
 | `prod-interop`        | Interoperabilità | ✅ All environments    |
 | `prod-io-premium`     | IO Premium       | ✅ All environments    |
 | `prod-io-sign`        | Firma con IO     | ✅ All environments    |
-| `prod-rtp`            | Request To Pay   | ⚠️ DEV/UAT only        |
+| `prod-rtp`            | Request To Pay   | ⚠️ UAT only            |
 
 #### Example Mapping (UAT Environment)
 
@@ -587,9 +587,11 @@ RESPONSABILE_PROTEZIONE_DATI | REFERENTE_BUSINESS_APICALE_ACCOUNT
 
 #### `nextstep` (string)
 
-**Description**: Next steps to be taken after this meeting.
+**Description**: Next steps to be taken after this meeting. This field is sent to Dynamics 365 as a native appointment field.
 
 **Example**: `"Preparare documentazione tecnica entro 7 giorni"`
+
+**Dynamics Field**: Stored in the native `nextstep` field of the appointment entity
 
 ---
 
@@ -1338,14 +1340,14 @@ GET /api/data/v9.2/accounts?$filter=pgp_identificativoselfcare eq '{uuid}'
 1. GrantAccess Custom Action not deployed in environment
 2. Team ID not configured correctly
 3. Team doesn't exist in Dynamics
-4. DEV/UAT environment limitations
+4. UAT environment limitations
 
 **Solutions**:
 
 1. Verify with CRM admin that GrantAccess API is available
 2. Check team ID in `_shared/utils/mappings.ts`
 3. Set `enableGrantAccess: false` to skip this step
-4. In DEV/UAT, always use `enableGrantAccess: false` unless specifically testing
+4. In UAT, always use `enableGrantAccess: false` unless specifically testing
 
 **⚠️ Non-Blocking**: This error doesn't prevent appointment creation!
 
@@ -1476,21 +1478,21 @@ traces
 
 ### DEV vs UAT vs PROD Differences
 
-| Aspect               | DEV                                    | UAT                                    | PROD                               |
-| -------------------- | -------------------------------------- | -------------------------------------- | ---------------------------------- |
-| **Base URL**         | `https://dev-pagopa.crm4.dynamics.com` | `https://uat-pagopa.crm4.dynamics.com` | `https://pagopa.crm4.dynamics.com` |
-| **Product GUIDs**    | DEV-specific                           | UAT-specific                           | PROD-specific                      |
-| **Team ID**          | Same as UAT                            | `5f9c165c-...`                         | `5f9c165c-...`                     |
-| **GrantAccess API**  | ⚠️ May not be available                | ⚠️ May not be available                | ✅ Available                       |
-| **Data Quality**     | Test data                              | Pre-production data                    | Production data                    |
-| **prod-rtp Product** | ✅ Available                           | ✅ Available                           | ❌ Not available                   |
+| Aspect               | UAT                                    | PROD                               |
+| -------------------- | -------------------------------------- | ---------------------------------- |
+| **Base URL**         | `https://uat-pagopa.crm4.dynamics.com` | `https://pagopa.crm4.dynamics.com` |
+| **Product GUIDs**    | UAT-specific                           | PROD-specific                      |
+| **Team ID**          | `5f9c165c-...`                         | `5f9c165c-...`                     |
+| **GrantAccess API**  | ⚠️ May not be available                | ✅ Available                       |
+| **Data Quality**     | Pre-production data                    | Production data                    |
+| **prod-rtp Product** | ✅ Available                           | ❌ Not available                   |
 
 #### Important Notes
 
 1. **Product GUIDs are different**: Don't copy configuration from one environment to another
-2. **GrantAccess in DEV/UAT**: May not be deployed; always test with `enableGrantAccess: false` first
-3. **Data Sync**: DEV and UAT may have outdated or incomplete data
-4. **prod-rtp**: Only available in DEV and UAT, not in PROD
+2. **GrantAccess in UAT**: May not be deployed; always test with `enableGrantAccess: false` first
+3. **Data Sync**: UAT may have outdated or incomplete data
+4. **prod-rtp**: Only available in UAT, not in PROD
 
 ---
 
@@ -1500,7 +1502,7 @@ traces
 
 - ✅ Standard appointments
 - ✅ Internal meetings
-- ✅ Testing in DEV/UAT environments
+- ✅ Testing in UAT environment
 - ✅ When Sales team visibility is not required
 - ✅ When you're unsure if GrantAccess is available
 

--- a/apps/sm-crm-fn/docs/API_GUIDE.md
+++ b/apps/sm-crm-fn/docs/API_GUIDE.md
@@ -585,23 +585,25 @@ RESPONSABILE_PROTEZIONE_DATI | REFERENTE_BUSINESS_APICALE_ACCOUNT
 
 ---
 
-#### `nextstep` (string)
+#### `categoria` (string)
 
-**Description**: Next steps to be taken after this meeting. This field is sent to Dynamics 365 as a native appointment field.
+**Description**: Category of the appointment. This field is sent to Dynamics 365 as the standard `category` field.
 
-**Example**: `"Preparare documentazione tecnica entro 7 giorni"`
+**Example**: `"Follow-up tecnico"`
 
-**Dynamics Field**: Stored in the native `nextstep` field of the appointment entity
+**Dynamics Field**: Stored in the standard `category` field of the appointment entity
 
 ---
 
-#### `dataProssimoContatto` (string, ISO 8601 date)
+#### `dataProssimoContatto` (string, ISO 8601 date-time)
 
-**Description**: Date of the next planned contact.
+**Description**: Date and time of the next planned contact. This field is mapped to the Dynamics 365 standard `sortdate` field.
 
-**Example**: `"2025-02-20"`
+**Example**: `"2025-02-20T10:00:00Z"`
 
-**Format**: ISO 8601 date (YYYY-MM-DD)
+**Format**: ISO 8601 date-time (YYYY-MM-DDTHH:mm:ssZ)
+
+**Dynamics Field**: Mapped to the standard `sortdate` (DateTime) field of the appointment entity
 
 ---
 
@@ -864,8 +866,9 @@ Content-Type: application/json
   "scheduledend": "2025-02-25T15:30:00Z",
   "location": "Microsoft Teams",
   "description": "Discussione dettagliata dei requisiti tecnici per l'integrazione della piattaforma pagoPA. Verranno presentati i flussi di onboarding, certificazione e gestione delle transazioni.",
-  "nextstep": "Preparare ambiente di test entro 7 giorni. Configurare credenziali API. Pianificare sessione di training tecnico.",
-  "dataProssimoContatto": "2025-03-05",
+  "categoria": "Follow-up tecnico",
+  "dataProssimoContatto": "2025-03-05T10:00:00Z",
+  "oggettoDelContatto": 100000005,
   "enableCreateContact": true,
   "enableGrantAccess": true,
   "enableFallback": false,
@@ -1602,8 +1605,9 @@ If GrantAccess consistently fails:
 - `partecipanti[].tipologiaReferente`
 - `location`
 - `description`
-- `nextstep`
+- `categoria`
 - `dataProssimoContatto`
+- `oggettoDelContatto`
 
 **Control Flags** (all optional):
 

--- a/apps/sm-crm-fn/meetings/handler.ts
+++ b/apps/sm-crm-fn/meetings/handler.ts
@@ -13,6 +13,10 @@ import {
 } from "../_shared/services/orchestrator";
 import { listAppointments } from "../_shared/services/appointments";
 import { createLogger } from "../_shared/utils/logger";
+import {
+  resolveDynamicsEnvironment,
+  getDynamicsBaseUrl,
+} from "../_shared/utils/requestEnvironment";
 
 // -----------------------------------------------------------------------------
 // POST /meetings - Crea appuntamento (orchestrato)
@@ -25,18 +29,23 @@ export async function createMeetingHandler(
   context.log("=== Create Meeting Request ===");
 
   try {
+    // Resolve Dynamics environment from header
+    const environment = resolveDynamicsEnvironment(request);
+    const baseUrl = getDynamicsBaseUrl(environment);
+
     const body = await request.json();
 
     // Validazione
     const validation = validateOrchestratorRequest(body);
     if (!validation.valid) {
-      context.warn("Validation errors:", validation.errors);
+      const errors = validation.errors;
+      context.warn("Validation errors:", errors);
       return {
         status: 400,
         jsonBody: {
           success: false,
           message: "Errore di validazione",
-          errors: validation.errors,
+          errors,
           timestamp: new Date().toISOString(),
         },
       };
@@ -47,8 +56,11 @@ export async function createMeetingHandler(
       context.log("🧪 DRY-RUN MODE ENABLED");
     }
 
-    // Esegui orchestratore
-    const result = await createMeetingOrchestrator(validation.data);
+    // Esegui orchestratore con baseUrl
+    const result = await createMeetingOrchestrator({
+      ...validation.data,
+      baseUrl,
+    });
 
     // Status code basato sul risultato
     let status = 201;
@@ -72,6 +84,18 @@ export async function createMeetingHandler(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     context.error("Unexpected error:", errorMessage);
+
+    // Check for environment resolution errors
+    if (errorMessage.includes("x-dynamics-environment")) {
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: errorMessage,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
 
     return {
       status: 500,
@@ -97,12 +121,16 @@ export async function listMeetingsHandler(
   logger.info("List Meetings request received");
 
   try {
+    // Resolve Dynamics environment from header
+    const environment = resolveDynamicsEnvironment(request);
+    const baseUrl = getDynamicsBaseUrl(environment);
+
     const top = request.query.get("top") ?? "50";
     const filter = request.query.get("filter") ?? undefined;
 
     logger.info("Listing appointments", { odataTop: top, odataFilter: filter });
 
-    const result = await listAppointments({ top, filter }, logger);
+    const result = await listAppointments({ top, filter }, logger, baseUrl);
     const count = result.value?.length ?? 0;
 
     logger.info("Appointments listed successfully", { resultCount: count });
@@ -119,6 +147,18 @@ export async function listMeetingsHandler(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error("Failed to list meetings", error);
+
+    // Check for environment resolution errors
+    if (errorMessage.includes("x-dynamics-environment")) {
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: errorMessage,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
 
     return {
       status: 500,
@@ -143,22 +183,28 @@ export async function dryRunMeetingHandler(
   context.log("=== Dry-Run Meeting Request ===");
 
   try {
+    // Resolve Dynamics environment from header
+    const environment = resolveDynamicsEnvironment(request);
+    const baseUrl = getDynamicsBaseUrl(environment);
+
     const body = await request.json();
 
     // Forza dry-run
     const requestWithDryRun = {
       ...(body as object),
       dryRun: true,
+      baseUrl,
     };
 
     const validation = validateOrchestratorRequest(requestWithDryRun);
     if (!validation.valid) {
+      const errors = validation.errors;
       return {
         status: 400,
         jsonBody: {
           success: false,
           message: "Errore di validazione",
-          errors: validation.errors,
+          errors,
           timestamp: new Date().toISOString(),
         },
       };
@@ -178,6 +224,18 @@ export async function dryRunMeetingHandler(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     context.error("Dry-run error:", errorMessage);
+
+    // Check for environment resolution errors
+    if (errorMessage.includes("x-dynamics-environment")) {
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: errorMessage,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
 
     return {
       status: 500,

--- a/apps/sm-crm-fn/meetings/handler.ts
+++ b/apps/sm-crm-fn/meetings/handler.ts
@@ -16,6 +16,7 @@ import { createLogger } from "../_shared/utils/logger";
 import {
   resolveDynamicsEnvironment,
   getDynamicsBaseUrl,
+  isInvalidDynamicsEnvironmentError,
 } from "../_shared/utils/requestEnvironment";
 
 // -----------------------------------------------------------------------------
@@ -82,21 +83,21 @@ export async function createMeetingHandler(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    context.error("Unexpected error:", errorMessage);
+    context.error("Unexpected error:", error);
 
     // Check for environment resolution errors
-    if (errorMessage.includes("x-dynamics-environment")) {
+    if (isInvalidDynamicsEnvironmentError(error)) {
       return {
         status: 400,
         jsonBody: {
           success: false,
-          message: errorMessage,
+          message: error.message,
           timestamp: new Date().toISOString(),
         },
       };
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       status: 500,
       jsonBody: {
@@ -130,7 +131,7 @@ export async function listMeetingsHandler(
 
     logger.info("Listing appointments", { odataTop: top, odataFilter: filter });
 
-    const result = await listAppointments({ top, filter }, logger, baseUrl);
+    const result = await listAppointments(baseUrl, { top, filter }, logger);
     const count = result.value?.length ?? 0;
 
     logger.info("Appointments listed successfully", { resultCount: count });
@@ -145,21 +146,21 @@ export async function listMeetingsHandler(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
     logger.error("Failed to list meetings", error);
 
     // Check for environment resolution errors
-    if (errorMessage.includes("x-dynamics-environment")) {
+    if (isInvalidDynamicsEnvironmentError(error)) {
       return {
         status: 400,
         jsonBody: {
           success: false,
-          message: errorMessage,
+          message: error.message,
           timestamp: new Date().toISOString(),
         },
       };
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       status: 500,
       jsonBody: {
@@ -222,21 +223,21 @@ export async function dryRunMeetingHandler(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    context.error("Dry-run error:", errorMessage);
+    context.error("Dry-run error:", error);
 
     // Check for environment resolution errors
-    if (errorMessage.includes("x-dynamics-environment")) {
+    if (isInvalidDynamicsEnvironmentError(error)) {
       return {
         status: 400,
         jsonBody: {
           success: false,
-          message: errorMessage,
+          message: error.message,
           timestamp: new Date().toISOString(),
         },
       };
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       status: 500,
       jsonBody: {

--- a/apps/sm-crm-fn/openapi.yaml
+++ b/apps/sm-crm-fn/openapi.yaml
@@ -19,6 +19,16 @@ info:
     ## Dry-Run Mode
     Tutti gli endpoint di creazione supportano la modalità `dryRun` per testare 
     il flusso senza effettuare modifiche su Dynamics CRM.
+
+    ## Supporto Multi-Ambiente
+    La funzione supporta il routing verso istanze UAT o PROD di Dynamics 365.
+
+    - **Header**: `x-dynamics-environment` (valori: `UAT` o `PROD`, case-insensitive)
+    - **Default**: Se l'header non è fornito, viene utilizzato PROD per retrocompatibilità
+    - **Validazione**: Se il valore dell'header non è valido, viene restituito un errore 400
+
+    Questo permette di testare le integrazioni in UAT e utilizzare PROD in produzione,
+    utilizzando lo stesso endpoint dell'Azure Function.
   version: 1.0.0
   contact:
     name: PagoPA S.p.A.
@@ -74,6 +84,8 @@ paths:
         Verifica la connettività con Microsoft Dynamics 365 CRM 
         effettuando una query di test sui contatti.
       operationId: pingDynamics
+      parameters:
+        - $ref: "#/components/parameters/DynamicsEnvironment"
       responses:
         "200":
           description: Connessione riuscita
@@ -81,6 +93,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PingResponse"
+        "400":
+          description: Parametri mancanti o invalidi (es. header x-dynamics-environment non valido)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "503":
           description: Connessione fallita
           content:
@@ -101,6 +119,7 @@ paths:
         - **name**: Nome dell'ente (fallback)
       operationId: getAccount
       parameters:
+        - $ref: "#/components/parameters/DynamicsEnvironment"
         - name: selfcareId
           in: query
           description: ID Selfcare dell'ente
@@ -161,6 +180,7 @@ paths:
         **Nota**: Specificare solo uno dei due parametri.
       operationId: getContacts
       parameters:
+        - $ref: "#/components/parameters/DynamicsEnvironment"
         - name: accountId
           in: query
           description: GUID dell'account (ente) per ottenere tutti i suoi contatti
@@ -215,6 +235,8 @@ paths:
         1. Verifica l'ente tramite `institutionIdSelfcare`
         2. Per ogni partecipante, crea il contatto collegandolo all'account e al prodotto
       operationId: createContacts
+      parameters:
+        - $ref: "#/components/parameters/DynamicsEnvironment"
       requestBody:
         required: true
         content:
@@ -269,6 +291,7 @@ paths:
       description: Recupera la lista degli appuntamenti da Dynamics CRM.
       operationId: listMeetings
       parameters:
+        - $ref: "#/components/parameters/DynamicsEnvironment"
         - name: top
           in: query
           description: Numero massimo di risultati da restituire
@@ -292,6 +315,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ListMeetingsResponse"
+        "400":
+          description: Parametri mancanti o invalidi (es. header x-dynamics-environment non valido)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Errore interno
           content:
@@ -314,6 +343,8 @@ paths:
         ### Dry-Run Mode
         Impostare `dryRun: true` per testare il flusso senza modifiche a Dynamics.
       operationId: createMeeting
+      parameters:
+        - $ref: "#/components/parameters/DynamicsEnvironment"
       requestBody:
         required: true
         content:
@@ -419,6 +450,8 @@ paths:
 
         Equivalente a `POST /meetings` con `dryRun: true`.
       operationId: dryRunMeeting
+      parameters:
+        - $ref: "#/components/parameters/DynamicsEnvironment"
       requestBody:
         required: true
         content:
@@ -459,6 +492,7 @@ paths:
         Non è destinato all'uso in produzione da parte del frontend.
       operationId: diagnosticsProbe
       parameters:
+        - $ref: "#/components/parameters/DynamicsEnvironment"
         - name: accountId
           in: query
           required: false
@@ -476,8 +510,32 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DiagnosticsProbeResponse"
+        "400":
+          description: Parametri mancanti o invalidi (es. header x-dynamics-environment non valido)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
 components:
+  parameters:
+    DynamicsEnvironment:
+      name: x-dynamics-environment
+      in: header
+      required: false
+      description: |
+        Specifica l'ambiente Dynamics 365 di destinazione.
+
+        - `UAT`: Ambiente di test Dynamics UAT
+        - `PROD`: Ambiente di produzione Dynamics (default)
+
+        Se l'header non è fornito, viene utilizzato PROD per retrocompatibilità.
+      schema:
+        type: string
+        enum: [UAT, PROD]
+        default: PROD
+      example: UAT
+
   schemas:
     # ==========================================================================
     # Request Schemas

--- a/apps/sm-crm-fn/openapi.yaml
+++ b/apps/sm-crm-fn/openapi.yaml
@@ -381,7 +381,9 @@ paths:
                   scheduledend: "2025-02-15T11:00:00Z"
                   location: "Google Meet"
                   description: "Discussione requisiti integrazione"
-                  oggettoDelContatto: 100000000
+                  oggettoDelContatto: 100000005
+                  categoria: "Follow-up tecnico"
+                  dataProssimoContatto: "2025-03-01T10:00:00Z"
                   enableCreateContact: true
                   enableGrantAccess: true
                   dryRun: false
@@ -595,9 +597,29 @@ components:
           type: integer
           description: |
             Oggetto del contatto (campo personalizzato Dynamics `pgp_oggettodelcontatto`).
-            È un valore **Picklist (Edm.Int32)** di Dynamics 365 — non una stringa libera.
-            I valori validi si recuperano tramite `GET /diagnostics/probe` (campo `oggettoDelContattoPicklist.options`).
-          example: 100000000
+            È un valore **Picklist (Edm.Int32)** di Dynamics 365.
+
+            **Valori validi:**
+            - `100000000`: Opportunità
+            - `100000001`: Post-Vendita
+            - `100000002`: Informativa
+            - `100000003`: Comunicazione
+            - `100000004`: Pre-Sales
+            - `100000005`: Integrazione Tecnica (default suggerito)
+          example: 100000005
+        categoria:
+          type: string
+          description: |
+            Categoria appuntamento (campo standard Dynamics `category`).
+            Campo testuale libero opzionale.
+          example: "Follow-up tecnico"
+        dataProssimoContatto:
+          type: string
+          format: date-time
+          description: |
+            Data prossimo contatto previsto (campo standard Dynamics `sortdate`).
+            Formato ISO 8601.
+          example: "2025-03-01T10:00:00Z"
         enableCreateContact:
           type: boolean
           default: false
@@ -927,7 +949,15 @@ components:
           type: integer
           description: |
             Oggetto del contatto — valore Picklist (Edm.Int32) da Dynamics 365.
-            I valori validi si recuperano tramite `GET /diagnostics/probe` (campo `oggettoDelContattoPicklist.options`).
+            Valori: 100000000 (Opportunità), 100000001 (Post-Vendita), 100000002 (Informativa),
+            100000003 (Comunicazione), 100000004 (Pre-Sales), 100000005 (Integrazione Tecnica).
+        category:
+          type: string
+          description: Categoria appuntamento (campo standard Dynamics)
+        sortdate:
+          type: string
+          format: date-time
+          description: Data prossimo contatto previsto (campo standard Dynamics)
 
     ErrorResponse:
       type: object

--- a/apps/sm-crm-fn/openapi.yaml
+++ b/apps/sm-crm-fn/openapi.yaml
@@ -523,15 +523,15 @@ components:
       in: header
       required: false
       description: |
-        Specifica l'ambiente Dynamics 365 di destinazione.
+        Specifica l'ambiente Dynamics 365 di destinazione (case-insensitive).
 
-        - `UAT`: Ambiente di test Dynamics UAT
-        - `PROD`: Ambiente di produzione Dynamics (default)
+        - `UAT` o `uat`: Ambiente di test Dynamics UAT
+        - `PROD` o `prod`: Ambiente di produzione Dynamics (default)
 
         Se l'header non è fornito, viene utilizzato PROD per retrocompatibilità.
       schema:
         type: string
-        enum: [UAT, PROD]
+        enum: [UAT, PROD, uat, prod]
         default: PROD
       example: UAT
 
@@ -1068,7 +1068,7 @@ components:
       properties:
         environment:
           type: string
-          enum: [UAT, PROD]
+          enum: [UAT, PROD, uat, prod]
           description: Ambiente rilevato dal DYNAMICS_BASE_URL
         dynamicsBaseUrl:
           type: string

--- a/apps/sm-crm-fn/openapi.yaml
+++ b/apps/sm-crm-fn/openapi.yaml
@@ -40,8 +40,6 @@ info:
 servers:
   - url: http://localhost:7071/api/v1
     description: Sviluppo locale
-  - url: https://sm-d-itn-pg-<service>-fn.azurewebsites.net/api/v1
-    description: Ambiente DEV
   - url: https://sm-u-itn-pg-<service>-fn.azurewebsites.net/api/v1
     description: Ambiente UAT
   - url: https://plsm-p-itn-crm-func-01.azurewebsites.net/api/v1
@@ -482,7 +480,7 @@ paths:
         con Dynamics 365 CRM.
 
         **Funzionalità:**
-        - Rileva l'ambiente corrente (DEV/UAT/PROD)
+        - Rileva l'ambiente corrente (UAT/PROD)
         - Proba i candidati per i nomi degli entity set OData
         - Lista le relazioni ManyToOne del contact verso entità `product`
         - Lista tutte le entità custom con prefisso `pgp_` e i loro entity set name
@@ -603,6 +601,10 @@ components:
           format: date
           description: Data del prossimo contatto previsto
           example: "2025-02-20"
+        oggettoDelContatto:
+          type: string
+          description: Oggetto del contatto (campo personalizzato Dynamics `pgp_oggettodelcontatto`)
+          example: "Supporto integrazione pagoPA"
         enableCreateContact:
           type: boolean
           default: false
@@ -624,7 +626,7 @@ components:
             Se `false` o omesso, lo step viene saltato completamente.
 
             **Nota**: GrantAccess richiede che l'API Custom Action sia disponibile 
-            nell'ambiente Dynamics. Potrebbe non essere disponibile in DEV/UAT.
+            nell'ambiente Dynamics. Potrebbe non essere disponibile in UAT.
 
             **Utilizzo consigliato**:
             - `false` (default): Per la maggior parte degli appuntamenti
@@ -639,13 +641,13 @@ components:
 
     Partecipante:
       type: object
-      required:
-        - email
       properties:
         email:
           type: string
-          format: email
-          description: Email del partecipante
+          description: |
+            Email del partecipante. Opzionale: se assente, il contatto non verrà
+            cercato per email. Può essere una stringa non formattata come indirizzo
+            email standard.
           example: "mario.rossi@ente.it"
         nome:
           type: string
@@ -928,6 +930,12 @@ components:
           type: integer
         statuscode:
           type: integer
+        nextstep:
+          type: string
+          description: Prossimi passi da intraprendere
+        pgp_oggettodelcontatto:
+          type: string
+          description: Oggetto del contatto (campo personalizzato Dynamics)
 
     ErrorResponse:
       type: object
@@ -1038,7 +1046,7 @@ components:
       properties:
         environment:
           type: string
-          enum: [DEV, UAT, PROD]
+          enum: [UAT, PROD]
           description: Ambiente rilevato dal DYNAMICS_BASE_URL
         dynamicsBaseUrl:
           type: string
@@ -1099,6 +1107,17 @@ components:
             error:
               type: string
               nullable: true
+        fieldValidation:
+          type: object
+          description: |
+            Verifica dell'esistenza dei campi utilizzati dall'applicazione sulle entità
+            `appointment` e `contact` in Dynamics 365. Utile per diagnosticare se un campo
+            custom (es. `pgp_oggettodelcontatto`) è presente nell'ambiente target.
+          properties:
+            appointment:
+              $ref: "#/components/schemas/EntityFieldProbeResult"
+            contact:
+              $ref: "#/components/schemas/EntityFieldProbeResult"
         recommendation:
           type: string
           nullable: true
@@ -1133,6 +1152,56 @@ components:
                     nullable: true
                   error:
                     type: string
+
+    EntityFieldProbeResult:
+      type: object
+      description: |
+        Risultato della validazione dei campi di un'entità Dynamics 365.
+        Riporta i campi trovati, quelli mancanti rispetto a quelli attesi,
+        e i navigation property (che non compaiono tra gli Attributes standard).
+      properties:
+        entity:
+          type: string
+          description: Nome logico dell'entità interrogata
+          example: "appointment"
+        fields:
+          type: array
+          description: Campi attesi effettivamente trovati in Dynamics (con tipo)
+          items:
+            type: object
+            properties:
+              logicalName:
+                type: string
+                example: "pgp_oggettodelcontatto"
+              attributeType:
+                type: string
+                example: "String"
+              expected:
+                type: boolean
+                description: True se il campo è nell'elenco dei campi attesi dall'applicazione
+              found:
+                type: boolean
+                description: Sempre true per i campi restituiti da Dynamics
+        missing:
+          type: array
+          description: |
+            Campi attesi dall'applicazione ma non trovati tra gli Attributes dell'entità.
+            Un campo in `missing` indica una potenziale incompatibilità con l'ambiente Dynamics.
+          items:
+            type: string
+          example: ["pgp_oggettodelcontatto"]
+        navigationProperties:
+          type: array
+          description: |
+            Navigation property dichiarati esplicitamente (es. lookup come `pgp_Prodottoid`).
+            Non compaiono tra gli Attributes standard di Dynamics e non vengono contati come `missing`.
+          items:
+            type: string
+          example: ["pgp_Prodottoid"]
+        error:
+          type: string
+          nullable: true
+          description: Errore durante l'interrogazione dei metadati, null se la chiamata è riuscita
 
     # ==========================================================================
     # Enums

--- a/apps/sm-crm-fn/openapi.yaml
+++ b/apps/sm-crm-fn/openapi.yaml
@@ -381,8 +381,7 @@ paths:
                   scheduledend: "2025-02-15T11:00:00Z"
                   location: "Google Meet"
                   description: "Discussione requisiti integrazione"
-                  nextstep: "Preparare documentazione tecnica"
-                  dataProssimoContatto: "2025-02-20"
+                  oggettoDelContatto: 100000000
                   enableCreateContact: true
                   enableGrantAccess: true
                   dryRun: false
@@ -592,19 +591,13 @@ components:
           type: string
           description: Descrizione dettagliata
           example: "Discussione requisiti integrazione pagoPA"
-        nextstep:
-          type: string
-          description: Prossimi passi da intraprendere
-          example: "Preparare documentazione tecnica"
-        dataProssimoContatto:
-          type: string
-          format: date
-          description: Data del prossimo contatto previsto
-          example: "2025-02-20"
         oggettoDelContatto:
-          type: string
-          description: Oggetto del contatto (campo personalizzato Dynamics `pgp_oggettodelcontatto`)
-          example: "Supporto integrazione pagoPA"
+          type: integer
+          description: |
+            Oggetto del contatto (campo personalizzato Dynamics `pgp_oggettodelcontatto`).
+            È un valore **Picklist (Edm.Int32)** di Dynamics 365 — non una stringa libera.
+            I valori validi si recuperano tramite `GET /diagnostics/probe` (campo `oggettoDelContattoPicklist.options`).
+          example: 100000000
         enableCreateContact:
           type: boolean
           default: false
@@ -930,12 +923,11 @@ components:
           type: integer
         statuscode:
           type: integer
-        nextstep:
-          type: string
-          description: Prossimi passi da intraprendere
         pgp_oggettodelcontatto:
-          type: string
-          description: Oggetto del contatto (campo personalizzato Dynamics)
+          type: integer
+          description: |
+            Oggetto del contatto — valore Picklist (Edm.Int32) da Dynamics 365.
+            I valori validi si recuperano tramite `GET /diagnostics/probe` (campo `oggettoDelContattoPicklist.options`).
 
     ErrorResponse:
       type: object
@@ -1118,6 +1110,31 @@ components:
               $ref: "#/components/schemas/EntityFieldProbeResult"
             contact:
               $ref: "#/components/schemas/EntityFieldProbeResult"
+        oggettoDelContattoPicklist:
+          type: object
+          description: |
+            Valori della Picklist `pgp_oggettodelcontatto` sull'entità `appointment`.
+            Contiene i valori interi (Edm.Int32) e le etichette recuperati dai metadati Dynamics.
+            Usare questi valori come `oggettoDelContatto` nella POST /meetings.
+          properties:
+            options:
+              type: array
+              description: Valori disponibili nella Picklist
+              items:
+                type: object
+                properties:
+                  value:
+                    type: integer
+                    description: Valore intero da inviare a Dynamics
+                    example: 100000000
+                  label:
+                    type: string
+                    description: Etichetta leggibile (preferibilmente in italiano)
+                    example: "Post-vendita"
+            error:
+              type: string
+              nullable: true
+              description: Errore durante il recupero dei valori, null se la chiamata è riuscita
         recommendation:
           type: string
           nullable: true

--- a/apps/sm-crm-fn/ping/handler.ts
+++ b/apps/sm-crm-fn/ping/handler.ts
@@ -7,6 +7,7 @@ import { listContacts } from "../_shared/services/contacts";
 import {
   resolveDynamicsEnvironment,
   getDynamicsBaseUrl,
+  isInvalidDynamicsEnvironmentError,
 } from "../_shared/utils/requestEnvironment";
 
 export async function handler(
@@ -32,21 +33,21 @@ export async function handler(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    context.error("Dynamics connectivity test failed:", errorMessage);
+    context.error("Dynamics connectivity test failed:", error);
 
     // Check for environment resolution errors
-    if (errorMessage.includes("x-dynamics-environment")) {
+    if (isInvalidDynamicsEnvironmentError(error)) {
       return {
         status: 400,
         jsonBody: {
           status: "error",
-          message: errorMessage,
+          message: error.message,
           timestamp: new Date().toISOString(),
         },
       };
     }
 
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       status: 503,
       jsonBody: {

--- a/apps/sm-crm-fn/ping/handler.ts
+++ b/apps/sm-crm-fn/ping/handler.ts
@@ -4,6 +4,10 @@ import type {
   InvocationContext,
 } from "@azure/functions";
 import { listContacts } from "../_shared/services/contacts";
+import {
+  resolveDynamicsEnvironment,
+  getDynamicsBaseUrl,
+} from "../_shared/utils/requestEnvironment";
 
 export async function handler(
   request: HttpRequest,
@@ -12,7 +16,11 @@ export async function handler(
   context.log("Ping endpoint - testing Dynamics connectivity");
 
   try {
-    const result = await listContacts({ top: "1" });
+    // Resolve Dynamics environment from header
+    const environment = resolveDynamicsEnvironment(request);
+    const baseUrl = getDynamicsBaseUrl(environment);
+
+    const result = await listContacts(baseUrl, { top: "1" });
 
     return {
       status: 200,
@@ -26,6 +34,18 @@ export async function handler(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     context.error("Dynamics connectivity test failed:", errorMessage);
+
+    // Check for environment resolution errors
+    if (errorMessage.includes("x-dynamics-environment")) {
+      return {
+        status: 400,
+        jsonBody: {
+          status: "error",
+          message: errorMessage,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    }
 
     return {
       status: 503,

--- a/apps/sm-fe-smcr/components/call-management/crm-form-schema.ts
+++ b/apps/sm-fe-smcr/components/call-management/crm-form-schema.ts
@@ -29,6 +29,25 @@ export const partecipanteSchema = z.object({
 
 const dynamicsEnvironmentValues = ["UAT", "PROD"] as const;
 
+/** Valori picklist Dynamics `pgp_oggettodelcontatto` (POST /meetings) */
+export const oggettoDelContattoOptions = [
+  { value: 100000000, label: "Opportunità" },
+  { value: 100000001, label: "Post - Vendita" },
+  { value: 100000002, label: "Informativa" },
+  { value: 100000003, label: "Comunicazione" },
+  { value: 100000004, label: "Pre- Sales" },
+  { value: 100000005, label: "Integrazione Tecnica" },
+] as const;
+
+const oggettoDelContattoPicklistSchema = z.union([
+  z.literal(100000000),
+  z.literal(100000001),
+  z.literal(100000002),
+  z.literal(100000003),
+  z.literal(100000004),
+  z.literal(100000005),
+]);
+
 export const crmFormSchema = z
   .object({
     dynamicsEnvironment: z.enum(dynamicsEnvironmentValues),
@@ -49,9 +68,9 @@ export const crmFormSchema = z
     dryRun: z.boolean(),
     location: z.string().optional(),
     description: z.string().optional(),
-    nextstep: z.string().optional(),
+    category: z.string().optional(),
     dataProssimoContatto: z.string().optional(),
-    oggettoDelContatto: z.string().optional(),
+    oggettoDelContatto: oggettoDelContattoPicklistSchema.optional(),
   })
   .refine(
     (data) => {
@@ -99,8 +118,8 @@ export function getCrmFormDefaultValues(): CrmFormSchema {
     dryRun: false,
     location: "",
     description: "",
-    nextstep: "",
+    category: "",
     dataProssimoContatto: "",
-    oggettoDelContatto: "",
+    oggettoDelContatto: 100000005,
   };
 }

--- a/apps/sm-fe-smcr/components/call-management/crm-form-schema.ts
+++ b/apps/sm-fe-smcr/components/call-management/crm-form-schema.ts
@@ -8,7 +8,17 @@ const productIds = [
   "prod-io-sign",
 ] as const;
 
-export const tipologiaReferenteValues = ["TECNICO"] as const;
+export const tipologiaReferenteValues = [
+  "APICALE",
+  "DIRETTO",
+  "TECNICO",
+  "BUSINESS",
+  "ACCOUNT",
+  "RESPONSABILE_DI_TRASFORMAZIONE_DIGITALE",
+  "REFERENTE_CONTRATTUALE",
+  "RESPONSABILE_PROTEZIONE_DATI",
+  "REFERENTE_BUSINESS_APICALE_ACCOUNT",
+] as const;
 
 export const partecipanteSchema = z.object({
   nome: z.string().min(1, "Nome obbligatorio"),
@@ -35,7 +45,13 @@ export const crmFormSchema = z
       .array(partecipanteSchema)
       .min(1, "Aggiungi almeno un partecipante"),
     enableCreateContact: z.boolean(),
+    enableGrantAccess: z.boolean(),
+    dryRun: z.boolean(),
+    location: z.string().optional(),
     description: z.string().optional(),
+    nextstep: z.string().optional(),
+    dataProssimoContatto: z.string().optional(),
+    oggettoDelContatto: z.string().optional(),
   })
   .refine(
     (data) => {
@@ -79,6 +95,12 @@ export function getCrmFormDefaultValues(): CrmFormSchema {
     institutionIdSelfcare: "",
     partecipanti: [],
     enableCreateContact: true,
+    enableGrantAccess: false,
+    dryRun: false,
+    location: "",
     description: "",
+    nextstep: "",
+    dataProssimoContatto: "",
+    oggettoDelContatto: "",
   };
 }

--- a/apps/sm-fe-smcr/components/call-management/crm-form-schema.ts
+++ b/apps/sm-fe-smcr/components/call-management/crm-form-schema.ts
@@ -11,14 +11,17 @@ const productIds = [
 export const tipologiaReferenteValues = ["TECNICO"] as const;
 
 export const partecipanteSchema = z.object({
-  nome: z.string().optional(),
-  cognome: z.string().optional(),
-  email: z.string().min(1, "Email obbligatoria").email("Email non valida"),
+  nome: z.string().min(1, "Nome obbligatorio"),
+  cognome: z.string().min(1, "Cognome obbligatorio"),
+  email: z.string().optional(),
   tipologiaReferente: z.enum(tipologiaReferenteValues),
 });
 
+const dynamicsEnvironmentValues = ["UAT", "PROD"] as const;
+
 export const crmFormSchema = z
   .object({
+    dynamicsEnvironment: z.enum(dynamicsEnvironmentValues),
     subject: z.string().min(1, "Inserire l'oggetto"),
     startDate: z.string().min(1, "Data inizio obbligatoria"),
     startTime: z.string().min(1, "Ora inizio obbligatoria"),
@@ -34,22 +37,20 @@ export const crmFormSchema = z
     enableCreateContact: z.boolean(),
     description: z.string().optional(),
   })
-  .refine((data) => data.partecipanti.some((p) => p.email?.trim().length > 0), {
-    message: "Almeno un partecipante deve avere un'email",
-    path: ["partecipanti"],
-  })
   .refine(
     (data) => {
-      const start =
-        new Date(`${data.startDate}T${data.startTime.length <= 5 ? `${data.startTime}:00` : data.startTime}`).getTime();
-      const end =
-        new Date(`${data.endDate}T${data.endTime.length <= 5 ? `${data.endTime}:00` : data.endTime}`).getTime();
+      const start = new Date(
+        `${data.startDate}T${data.startTime.length <= 5 ? `${data.startTime}:00` : data.startTime}`,
+      ).getTime();
+      const end = new Date(
+        `${data.endDate}T${data.endTime.length <= 5 ? `${data.endTime}:00` : data.endTime}`,
+      ).getTime();
       return start < end;
     },
     {
       message: "Data e ora di inizio devono essere prima di data e ora di fine",
       path: ["endDate"],
-    }
+    },
   );
 
 export type CrmFormSchema = z.infer<typeof crmFormSchema>;
@@ -68,6 +69,7 @@ export function getCrmFormDefaultValues(): CrmFormSchema {
   const now = new Date();
   const end = new Date(now.getTime() + 60 * 60 * 1000);
   return {
+    dynamicsEnvironment: "PROD",
     subject: "",
     startDate: toDateString(now),
     startTime: toTimeString(now),

--- a/apps/sm-fe-smcr/components/call-management/crm-form.tsx
+++ b/apps/sm-fe-smcr/components/call-management/crm-form.tsx
@@ -38,6 +38,7 @@ import { toast } from "sonner";
 import {
   getCrmFormDefaultValues,
   crmFormSchema,
+  tipologiaReferenteValues,
   type CrmFormSchema,
 } from "./crm-form-schema";
 import {
@@ -46,9 +47,11 @@ import {
   type TipologiaReferente,
 } from "@/lib/actions/call-management.action";
 
-const TIPOLOGIA_OPTIONS: { value: TipologiaReferente; label: string }[] = [
-  { value: "TECNICO", label: "TECNICO" },
-];
+const TIPOLOGIA_OPTIONS: { value: TipologiaReferente; label: string }[] =
+  tipologiaReferenteValues.map((value) => ({
+    value,
+    label: value,
+  }));
 
 function toIsoDateTime(dateStr: string, timeStr: string): string {
   const normalized = timeStr.length <= 5 ? `${timeStr}:00` : timeStr;
@@ -126,8 +129,14 @@ export default function CRMForm() {
       subject: values.subject,
       scheduledstart: toIsoDateTime(values.startDate, values.startTime),
       scheduledend: toIsoDateTime(values.endDate, values.endTime),
+      location: values.location?.trim() || undefined,
       description: values.description?.trim() || undefined,
+      nextstep: values.nextstep?.trim() || undefined,
+      dataProssimoContatto: values.dataProssimoContatto || undefined,
+      oggettoDelContatto: values.oggettoDelContatto?.trim() || undefined,
       enableCreateContact: values.enableCreateContact,
+      enableGrantAccess: values.enableGrantAccess,
+      dryRun: values.dryRun,
     };
     console.log("payLoad", payLoad);
     const result = await createMeetingAction(payLoad);
@@ -508,6 +517,125 @@ export default function CRMForm() {
                     />
                   </FormControl>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="location"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="location">Luogo</FormLabel>
+                  <FormControl>
+                    <Input
+                      id="location"
+                      placeholder="Es. Meet / Teams / sede"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="nextstep"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="nextstep">Prossimi passi</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      id="nextstep"
+                      placeholder="Azioni successive concordate"
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="dataProssimoContatto"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel htmlFor="dataProssimoContatto">
+                      Data prossimo contatto
+                    </FormLabel>
+                    <FormControl>
+                      <Input id="dataProssimoContatto" type="date" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="oggettoDelContatto"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel htmlFor="oggettoDelContatto">
+                      Oggetto del contatto
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        id="oggettoDelContatto"
+                        placeholder="Es. supporto integrazione"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="enableGrantAccess"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center gap-3 space-y-0 rounded-md border p-4">
+                  <FormControl>
+                    <Switch
+                      id="enableGrantAccess"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <div className="space-y-0.5 leading-none">
+                    <FormLabel
+                      htmlFor="enableGrantAccess"
+                      className="cursor-pointer"
+                    >
+                      Abilita Grant Access
+                    </FormLabel>
+                  </div>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="dryRun"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center gap-3 space-y-0 rounded-md border p-4">
+                  <FormControl>
+                    <Switch
+                      id="dryRun"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <div className="space-y-0.5 leading-none">
+                    <FormLabel htmlFor="dryRun" className="cursor-pointer">
+                      Esegui in Dry Run
+                    </FormLabel>
+                  </div>
                 </FormItem>
               )}
             />

--- a/apps/sm-fe-smcr/components/call-management/crm-form.tsx
+++ b/apps/sm-fe-smcr/components/call-management/crm-form.tsx
@@ -545,9 +545,13 @@ export default function CRMForm() {
               name="category"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel htmlFor="category">Categoria</FormLabel>
+                  <FormLabel htmlFor="category">Prossimi Passi</FormLabel>
                   <FormControl>
-                    <Input id="category" placeholder="Categoria" {...field} />
+                    <Input
+                      id="category"
+                      placeholder="Prossimi Passi"
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/apps/sm-fe-smcr/components/call-management/crm-form.tsx
+++ b/apps/sm-fe-smcr/components/call-management/crm-form.tsx
@@ -38,6 +38,7 @@ import { toast } from "sonner";
 import {
   getCrmFormDefaultValues,
   crmFormSchema,
+  oggettoDelContattoOptions,
   tipologiaReferenteValues,
   type CrmFormSchema,
 } from "./crm-form-schema";
@@ -131,9 +132,9 @@ export default function CRMForm() {
       scheduledend: toIsoDateTime(values.endDate, values.endTime),
       location: values.location?.trim() || undefined,
       description: values.description?.trim() || undefined,
-      nextstep: values.nextstep?.trim() || undefined,
+      category: values.category?.trim() || undefined,
       dataProssimoContatto: values.dataProssimoContatto || undefined,
-      oggettoDelContatto: values.oggettoDelContatto?.trim() || undefined,
+      oggettoDelContatto: values.oggettoDelContatto,
       enableCreateContact: values.enableCreateContact,
       enableGrantAccess: values.enableGrantAccess,
       dryRun: values.dryRun,
@@ -541,17 +542,12 @@ export default function CRMForm() {
 
             <FormField
               control={form.control}
-              name="nextstep"
+              name="category"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel htmlFor="nextstep">Prossimi passi</FormLabel>
+                  <FormLabel htmlFor="category">Categoria</FormLabel>
                   <FormControl>
-                    <Textarea
-                      id="nextstep"
-                      placeholder="Azioni successive concordate"
-                      rows={3}
-                      {...field}
-                    />
+                    <Input id="category" placeholder="Categoria" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -582,13 +578,32 @@ export default function CRMForm() {
                     <FormLabel htmlFor="oggettoDelContatto">
                       Oggetto del contatto
                     </FormLabel>
-                    <FormControl>
-                      <Input
-                        id="oggettoDelContatto"
-                        placeholder="Es. supporto integrazione"
-                        {...field}
-                      />
-                    </FormControl>
+                    <Select
+                      onValueChange={(v) =>
+                        field.onChange(Number.parseInt(v, 10))
+                      }
+                      value={
+                        field.value !== undefined
+                          ? String(field.value)
+                          : undefined
+                      }
+                    >
+                      <FormControl>
+                        <SelectTrigger
+                          id="oggettoDelContatto"
+                          className="w-full"
+                        >
+                          <SelectValue placeholder="Seleziona oggetto del contatto" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {oggettoDelContattoOptions.map(({ value, label }) => (
+                          <SelectItem key={value} value={String(value)}>
+                            {label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/apps/sm-fe-smcr/components/call-management/crm-form.tsx
+++ b/apps/sm-fe-smcr/components/call-management/crm-form.tsx
@@ -107,18 +107,19 @@ export default function CRMForm() {
 
   const onSubmit = async (values: CrmFormSchema) => {
     const partecipanti = values.partecipanti
-      .filter((p) => p.email.trim())
+      .filter((p) => p.nome.trim() && p.cognome.trim())
       .map((p) => ({
-        email: p.email.trim(),
-        nome: p.nome?.trim() || undefined,
-        cognome: p.cognome?.trim() || undefined,
+        email: p.email?.trim() || undefined,
+        nome: p.nome!.trim(),
+        cognome: p.cognome!.trim(),
         tipologiaReferente: p.tipologiaReferente,
       }));
     if (partecipanti.length === 0) {
-      toast.error("Aggiungi almeno un partecipante con email");
+      toast.error("Aggiungi almeno un partecipante con nome e cognome");
       return;
     }
     const payLoad: CreateMeetingInput = {
+      dynamicsEnvironment: values.dynamicsEnvironment,
       institutionIdSelfcare: values.institutionIdSelfcare,
       productIdSelfcare: values.productId,
       partecipanti,
@@ -146,6 +147,31 @@ export default function CRMForm() {
       >
         <FieldSet className="pt-4">
           <FieldGroup>
+            <FormField
+              control={form.control}
+              name="dynamicsEnvironment"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="dynamics-environment">Ambiente</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger
+                        id="dynamics-environment"
+                        className="w-full"
+                      >
+                        <SelectValue placeholder="Seleziona ambiente" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="PROD">PROD</SelectItem>
+                      <SelectItem value="UAT">UAT</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
             <FormField
               control={form.control}
               name="subject"

--- a/apps/sm-fe-smcr/lib/actions/call-management.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/call-management.action.ts
@@ -272,8 +272,14 @@ export type CreateMeetingInput = {
   subject: string;
   scheduledstart: string;
   scheduledend: string;
+  location?: string;
   description?: string;
+  nextstep?: string;
+  dataProssimoContatto?: string;
+  oggettoDelContatto?: string;
   enableCreateContact?: boolean;
+  enableGrantAccess?: boolean;
+  dryRun?: boolean;
   dynamicsEnvironment?: DynamicsCrmEnvironment;
 };
 
@@ -312,12 +318,30 @@ export async function createMeetingAction(
     subject: input.subject,
     scheduledstart: input.scheduledstart,
     scheduledend: input.scheduledend,
+    ...(input.location !== undefined && input.location !== ""
+      ? { location: input.location }
+      : {}),
     ...(input.description !== undefined && input.description !== ""
       ? { description: input.description }
+      : {}),
+    ...(input.nextstep !== undefined && input.nextstep !== ""
+      ? { nextstep: input.nextstep }
+      : {}),
+    ...(input.dataProssimoContatto !== undefined &&
+    input.dataProssimoContatto !== ""
+      ? { dataProssimoContatto: input.dataProssimoContatto }
+      : {}),
+    ...(input.oggettoDelContatto !== undefined &&
+    input.oggettoDelContatto !== ""
+      ? { oggettoDelContatto: input.oggettoDelContatto }
       : {}),
     ...(input.enableCreateContact !== undefined
       ? { enableCreateContact: input.enableCreateContact }
       : {}),
+    ...(input.enableGrantAccess !== undefined
+      ? { enableGrantAccess: input.enableGrantAccess }
+      : {}),
+    ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
   };
 
   try {

--- a/apps/sm-fe-smcr/lib/actions/call-management.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/call-management.action.ts
@@ -6,6 +6,7 @@ import z from "zod";
 import { PRODUCT_MAP } from "../types/product";
 import logger from "@/lib/logger/logger.server";
 import { serverEnv } from "@/config/env";
+import { tipologiaReferenteValues } from "@/components/call-management/crm-form-schema";
 
 const formatItalianDateTime = (value: string) => {
   const isoMatch =
@@ -253,16 +254,16 @@ export async function sendToSlackAction(
 
 // --- CRM Meeting (OpenAPI sm-crm-fn POST /meetings) ---
 
-const TIPOLOGIA_REFERENTE = ["TECNICO"] as const;
-
-export type TipologiaReferente = (typeof TIPOLOGIA_REFERENTE)[number];
+export type TipologiaReferente = (typeof tipologiaReferenteValues)[number];
 
 export type CreateMeetingPartecipante = {
-  email: string;
+  email?: string;
   nome?: string;
   cognome?: string;
   tipologiaReferente?: TipologiaReferente;
 };
+
+export type DynamicsCrmEnvironment = "UAT" | "PROD";
 
 export type CreateMeetingInput = {
   institutionIdSelfcare: string;
@@ -273,7 +274,7 @@ export type CreateMeetingInput = {
   scheduledend: string;
   description?: string;
   enableCreateContact?: boolean;
-  dryRun?: boolean;
+  dynamicsEnvironment?: DynamicsCrmEnvironment;
 };
 
 export type CreateMeetingResult =
@@ -283,6 +284,7 @@ export type CreateMeetingResult =
 export async function createMeetingAction(
   input: CreateMeetingInput,
 ): Promise<CreateMeetingResult> {
+  console.log("input", input);
   const baseUrl = serverEnv.FE_SMCR_CRM_API_URL?.replace(/\/$/, "");
   if (!baseUrl) {
     logger.warn(
@@ -293,8 +295,11 @@ export async function createMeetingAction(
   }
 
   const url = `${baseUrl}/meetings`;
+  const dynamicsEnv: DynamicsCrmEnvironment =
+    input.dynamicsEnvironment ?? "PROD";
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    "x-dynamics-environment": dynamicsEnv,
   };
   if (serverEnv.FE_SMCR_CRM_API_KEY) {
     headers["x-functions-key"] = serverEnv.FE_SMCR_CRM_API_KEY;
@@ -313,7 +318,6 @@ export async function createMeetingAction(
     ...(input.enableCreateContact !== undefined
       ? { enableCreateContact: input.enableCreateContact }
       : {}),
-    ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
   };
 
   try {
@@ -334,7 +338,10 @@ export async function createMeetingAction(
         {
           request: { method: "POST", path: url, statusCode: res.status },
           error: { message },
-          info: { event: "call-management.create-meeting.failed" },
+          info: {
+            event: "call-management.create-meeting.failed",
+            metadata: { dynamicsEnvironment: dynamicsEnv },
+          },
         },
         "createMeetingAction failed",
       );
@@ -345,7 +352,10 @@ export async function createMeetingAction(
       {
         info: {
           event: "call-management.create-meeting.success",
-          metadata: { activityId: data?.activityId },
+          metadata: {
+            activityId: data?.activityId,
+            dynamicsEnvironment: dynamicsEnv,
+          },
         },
       },
       "createMeetingAction success",

--- a/apps/sm-fe-smcr/lib/actions/call-management.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/call-management.action.ts
@@ -274,9 +274,9 @@ export type CreateMeetingInput = {
   scheduledend: string;
   location?: string;
   description?: string;
-  nextstep?: string;
+  category?: string;
   dataProssimoContatto?: string;
-  oggettoDelContatto?: string;
+  oggettoDelContatto?: number;
   enableCreateContact?: boolean;
   enableGrantAccess?: boolean;
   dryRun?: boolean;
@@ -324,15 +324,14 @@ export async function createMeetingAction(
     ...(input.description !== undefined && input.description !== ""
       ? { description: input.description }
       : {}),
-    ...(input.nextstep !== undefined && input.nextstep !== ""
-      ? { nextstep: input.nextstep }
+    ...(input.category !== undefined && input.category !== ""
+      ? { categoria: input.category }
       : {}),
     ...(input.dataProssimoContatto !== undefined &&
     input.dataProssimoContatto !== ""
       ? { dataProssimoContatto: input.dataProssimoContatto }
       : {}),
-    ...(input.oggettoDelContatto !== undefined &&
-    input.oggettoDelContatto !== ""
+    ...(input.oggettoDelContatto !== undefined
       ? { oggettoDelContatto: input.oggettoDelContatto }
       : {}),
     ...(input.enableCreateContact !== undefined

--- a/infra/resources/environments/prod.yaml
+++ b/infra/resources/environments/prod.yaml
@@ -109,11 +109,16 @@ fe_smcr:
 
 # ─── CRM Function (Dynamics CRM Integration) ─────────────────────────────────
 # Production = Staging (stessi valori per entrambi gli slot)
+# Supporta multi-environment: PROD e UAT Dynamics instances
 
 crm_function:
   __local: yaml_crm_func
+  # PROD environment (default)
   DYNAMICS_BASE_URL: "kv:dynamics_base_url"
   DYNAMICS_URL_CONTACTS: "kv:dynamics_url_contacts"
+  # UAT environment (utilizzato con header x-dynamics-environment: UAT)
+  DYNAMICS_BASE_URL_UAT: "kv:dynamics_base_url_uat"
+  DYNAMICS_URL_CONTACTS_UAT: "kv:dynamics_url_contacts_uat"
   NODE_ENV: "production"
   WEBSITE_RUN_FROM_PACKAGE: "1"
   DEBUG: "true"

--- a/infra/resources/prod/data_kv.tf
+++ b/infra/resources/prod/data_kv.tf
@@ -1,8 +1,18 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-03-16 09:50
+# Generato il: 2026-03-18 13:42
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
+
+data "azurerm_key_vault_secret" "dynamics_base_url_uat" {
+  name         = "dynamics-base-url-uat"
+  key_vault_id = module.azure_core_infra.common_key_vault.id
+}
+
+data "azurerm_key_vault_secret" "dynamics_url_contacts_uat" {
+  name         = "dynamics-url-contacts-uat"
+  key_vault_id = module.azure_core_infra.common_key_vault.id
+}
 
 data "azurerm_key_vault_secret" "fe_smcr_api_key_firma_con_io_signer_id" {
   name         = "fe-smcr-api-key-firma-con-io-signerid"

--- a/infra/resources/prod/locals_yaml.tf
+++ b/infra/resources/prod/locals_yaml.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-03-16 09:50
+# Generato il: 2026-03-18 13:42
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 
@@ -283,11 +283,13 @@ locals {
   # ────────────────────────────────────────────────────────────
 
   yaml_crm_func_app_settings = {
-    DYNAMICS_BASE_URL        = data.azurerm_key_vault_secret.dynamics_base_url.value
-    DYNAMICS_URL_CONTACTS    = data.azurerm_key_vault_secret.dynamics_url_contacts.value
-    NODE_ENV                 = "production"
-    WEBSITE_RUN_FROM_PACKAGE = "1"
-    DEBUG                    = "true"
+    DYNAMICS_BASE_URL         = data.azurerm_key_vault_secret.dynamics_base_url.value
+    DYNAMICS_URL_CONTACTS     = data.azurerm_key_vault_secret.dynamics_url_contacts.value
+    DYNAMICS_BASE_URL_UAT     = data.azurerm_key_vault_secret.dynamics_base_url_uat.value
+    DYNAMICS_URL_CONTACTS_UAT = data.azurerm_key_vault_secret.dynamics_url_contacts_uat.value
+    NODE_ENV                  = "production"
+    WEBSITE_RUN_FROM_PACKAGE  = "1"
+    DEBUG                     = "true"
   }
 
   yaml_crm_func_slot_app_settings = local.yaml_crm_func_app_settings


### PR DESCRIPTION
# Resoconto

Con questa PR introduciamo un valore non obbligatorio da poter inserire nell'header di una richiesta verso il CRM: `x-dynamics-environment` con valori attesi: `UAT` o `PROD` (case-insensitive). Nel caso in cui il valore non fosse passato, il valore di default previsto è `PROD`.

## Cosa è stato fatto

* Create 2 nuove ENV Variabiles su infrastruttura che fanno riferimento all'ambiente UAT i cui valori sono inseriti nel Key Vault Azure
* Aggiornato le varie funzioni `endpoint` interne per accettare questo nuovo parametro
* Aggiornata la documentazione
* Rimosso l'ambiente `DEV` e rimangono solo → `"UAT" | "PROD"`
* Rimossi blocchi `DEV` da `PRODUCTS_MAP`, `TEAMS_MAP`, `BASE_URLS` in `mappings.ts`
* `resolveEnvironment()` non mappa più `dev-pagopa`
* OpenAPI: rimosso server DEV, rimosso `DEV` dall'enum della response diagnostics

### Nuovi campi sul meeting

| Campo | Entità Dynamics | Note |
|---|---|---|
| `nextstep` | `appointment` | Prossimi passi |
| `oggettoDelContatto` → `pgp_oggettodelcontatto` | `appointment` | Campo custom opzionale |
| `dataProssimoContatto` → `new_dataprossimocontatto` | `appointment` | Data prossimo contatto |
### Email partecipante opzionale
`Partecipante.email` è ora opzionale: se assente, la ricerca per email viene skippata
e il contatto può essere creato senza indirizzo email.
Aggiunto escape `'` → `''` nella query OData per prevenire injection in `searchContactsByEmail`.
### Feature flag `ENABLE_EMAIL_FORMAT_VALIDATION`
Aggiunto come variabile d'ambiente opzionale (default `false`).
Non crasha se non impostato in Terraform. Legge da `process.env` direttamente
nel punto di validazione.
### Diagnostics probe — field validation
`GET /diagnostics/probe` ora include una sezione `fieldValidation` che interroga
le API OData di metadati di Dynamics per verificare se i campi utilizzati
dall'applicazione esistono effettivamente nell'ambiente target:
```json
"fieldValidation": {
  "appointment": {
    "entity": "appointment",
    "fields": [{ "logicalName": "pgp_oggettodelcontatto", "attributeType": "String", "expected": true, "found": true }],
    "missing": [],
    "navigationProperties": [],
    "error": null
  },
  "contact": {
    "entity": "contact",
    "fields": [...],
    "missing": [],
    "navigationProperties": ["pgp_Prodottoid"],
    "error": null
  }
}
```

### OpenAPI

- Nuovi campi oggettoDelContatto e pgp_oggettodelcontatto in CreateMeetingRequest e Appointment
- Partecipante.email resa opzionale (rimossa da required, rimosso format: email)
- Nuovo schema EntityFieldProbeResult e sezione fieldValidation in DiagnosticsProbeResponse