### PR TITLE
[SMION-720] Require confirmation before deleting delegations

### DIFF
--- a/apps/sm-fe-smcr/components/provisioning/product/delegations/table/columns.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/product/delegations/table/columns.tsx
@@ -48,9 +48,15 @@ export const columns: ColumnDef<Delegation>[] = [
   {
     id: "actions",
     cell: ({ row }) => {
-      const id = row.original.id;
+      const { id, brokerName, brokerTaxCode } = row.original;
 
-      return <DeleteDelegation id={id} />;
+      return (
+        <DeleteDelegation
+          id={id}
+          brokerName={brokerName}
+          brokerTaxCode={brokerTaxCode}
+        />
+      );
     },
   },
 ];

--- a/apps/sm-fe-smcr/components/provisioning/product/delegations/table/delete-delegation.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/product/delegations/table/delete-delegation.tsx
@@ -1,49 +1,111 @@
 "use client";
 
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { deleteDelegationAction } from "@/lib/actions/delegation.action";
 import { TrashIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { toast } from "sonner";
 
-export default function DeleteDelegation({ id }: { id: string }) {
+type Props = {
+  id: string;
+  brokerName: string;
+  brokerTaxCode: string;
+};
+
+export default function DeleteDelegation({
+  id,
+  brokerName,
+  brokerTaxCode,
+}: Props) {
   const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
   const [state, action, isPending] = useActionState(deleteDelegationAction, {
     fields: { id: "" },
   });
 
   useEffect(() => {
-    if (state.fields.id) {
-      if (state.errors) {
-        if (state.errors.root) {
-          toast.error(
-            state.errors.root || "Errore durante l'eliminazione della delega.",
-          );
-        }
-      } else {
-        toast.success("Delega eliminata correttamente.");
-        router.refresh();
-      }
+    if (!isSubmitted || isPending) {
+      return;
     }
-  }, [state]);
+
+    if (state.errors) {
+      toast.error(
+        state.errors.root || "Errore durante l'eliminazione della delega.",
+      );
+      setIsSubmitted(false);
+      return;
+    }
+
+    if (state.fields.id) {
+      toast.success("Delega eliminata correttamente.");
+      setIsSubmitted(false);
+      setOpen(false);
+      router.refresh();
+    }
+  }, [isPending, isSubmitted, router, state]);
 
   return (
-    <form action={action}>
-      <input type="hidden" name="id" value={id} />
-      <Button
-        type="submit"
-        variant="ghost"
-        className="size-8 p-0"
-        disabled={isPending}
-      >
-        {isPending ? (
-          <Spinner className="size-3.5 opacity-60" />
-        ) : (
-          <TrashIcon className="size-3.5 opacity-60" />
-        )}
-      </Button>
-    </form>
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isPending) {
+          setOpen(nextOpen);
+        }
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          className="size-8 p-0"
+          disabled={isPending}
+        >
+          {isPending ? (
+            <Spinner className="size-3.5 opacity-60" />
+          ) : (
+            <TrashIcon className="size-3.5 opacity-60" />
+          )}
+          <span className="sr-only">Elimina delega</span>
+        </Button>
+      </AlertDialogTrigger>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Elimina delega</AlertDialogTitle>
+          <AlertDialogDescription>
+            {`Stai per eliminare definitivamente la delega per ${brokerName} (${brokerTaxCode}). Questa operazione non puo essere annullata.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <form action={action} onSubmit={() => setIsSubmitted(true)}>
+          <input type="hidden" name="id" value={id} />
+
+          <AlertDialogFooter>
+            <AlertDialogCancel asChild>
+              <Button type="button" variant="outline" disabled={isPending}>
+                Annulla
+              </Button>
+            </AlertDialogCancel>
+            <Button type="submit" variant="destructive" disabled={isPending}>
+              {isPending ? <Spinner className="size-3.5" /> : null}
+              Elimina delega
+            </Button>
+          </AlertDialogFooter>
+        </form>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/apps/sm-fe-smcr/components/provisioning/product/delegations/table/delete-delegation.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/product/delegations/table/delete-delegation.tsx
@@ -86,7 +86,7 @@ export default function DeleteDelegation({
         <AlertDialogHeader>
           <AlertDialogTitle>Elimina delega</AlertDialogTitle>
           <AlertDialogDescription>
-            {`Stai per eliminare definitivamente la delega per ${brokerName} (${brokerTaxCode}). Questa operazione non puo essere annullata.`}
+            {`Stai per eliminare definitivamente la delega per ${brokerName} (${brokerTaxCode}). Questa operazione non può essere annullata.`}
           </AlertDialogDescription>
         </AlertDialogHeader>
 


### PR DESCRIPTION
- add a confirmation dialog before deleting a delegation
- show delegate name and tax code in the confirmation message
- preserve the current loading, toast, and refresh flow after deletion