### PR TITLE
[SMION-641] Members: hide ID column and add member deletion from sheet

### DIFF
--- a/apps/sm-fe-smcr/components/members/sheet/member-sheet.tsx
+++ b/apps/sm-fe-smcr/components/members/sheet/member-sheet.tsx
@@ -1,4 +1,15 @@
+"use client";
+
 import { CardRow } from "@/components/core/card-row";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -10,7 +21,10 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { Spinner } from "@/components/ui/spinner";
+import { deleteMemberAction } from "@/lib/actions/members.action";
 import { MemberWithTeams } from "@/lib/services/members.service";
+import useAuthStore from "@/lib/store/auth.store";
 import useTeamsStore from "@/lib/store/teams.store";
 import {
   CalendarIcon,
@@ -19,6 +33,9 @@ import {
   MailIcon,
   UserIcon,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useState, useTransition } from "react";
+import { toast } from "sonner";
 import TeamCheckbox from "./team-checkbox";
 
 type Props = {
@@ -28,9 +45,69 @@ type Props = {
 
 export function MemberSheet({ children, member }: Props) {
   const teams = useTeamsStore((state) => state.teams);
+  const authUser = useAuthStore((state) => state.user);
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeletePending, startDeleteTransition] = useTransition();
+  const isCurrentUser = authUser?.id === member.id;
+
+  const handleSheetOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (isDeletePending) {
+        return;
+      }
+
+      setOpen(nextOpen);
+
+      if (!nextOpen) {
+        setIsDeleteDialogOpen(false);
+      }
+    },
+    [isDeletePending],
+  );
+
+  const handleDeleteDialogOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (isDeletePending) {
+        return;
+      }
+
+      setIsDeleteDialogOpen(nextOpen);
+    },
+    [isDeletePending],
+  );
+
+  const handleMemberDelete = useCallback(() => {
+    if (isCurrentUser) {
+      return;
+    }
+
+    startDeleteTransition(async () => {
+      const formData = new FormData();
+      formData.set("memberId", String(member.id));
+
+      const result = await deleteMemberAction(undefined, formData);
+
+      if (result.error) {
+        toast.error(
+          "Eliminazione utente non riuscita",
+          result.error.root ? { description: result.error.root } : undefined,
+        );
+        return;
+      }
+
+      toast.success(
+        `L'utente ${member.firstname} ${member.lastname} è stato eliminato.`,
+      );
+      setIsDeleteDialogOpen(false);
+      setOpen(false);
+      router.refresh();
+    });
+  }, [isCurrentUser, member.firstname, member.id, member.lastname, router]);
 
   return (
-    <Sheet>
+    <Sheet open={open} onOpenChange={handleSheetOpenChange}>
       <SheetTrigger asChild>{children}</SheetTrigger>
       <SheetContent className="sm:max-w-xl">
         <SheetHeader>
@@ -91,12 +168,65 @@ export function MemberSheet({ children, member }: Props) {
           </div>
         </div>
 
-        <SheetFooter className="flex flex-row w-full items-center justify-end">
-          <SheetClose asChild>
-            <Button variant="outline">Annulla</Button>
-          </SheetClose>
+        <SheetFooter className="w-full gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-xs text-muted-foreground">
+            {isCurrentUser ? "Non puoi eliminare il tuo utente." : null}
+          </div>
+
+          <div className="flex w-full flex-col-reverse gap-2 sm:w-auto sm:flex-row sm:items-center">
+            <SheetClose asChild>
+              <Button variant="outline" disabled={isDeletePending}>
+                Annulla
+              </Button>
+            </SheetClose>
+
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => setIsDeleteDialogOpen(true)}
+              disabled={isDeletePending || isCurrentUser}
+            >
+              Elimina utente
+            </Button>
+          </div>
         </SheetFooter>
       </SheetContent>
+
+      <AlertDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={handleDeleteDialogOpenChange}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Elimina utente</AlertDialogTitle>
+            <AlertDialogDescription>
+              {`Stai per eliminare definitivamente l'utente ${member.firstname} ${member.lastname}. Questa operazione non può essere annullata.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel asChild>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isDeletePending}
+              >
+                Annulla
+              </Button>
+            </AlertDialogCancel>
+
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleMemberDelete}
+              disabled={isDeletePending || isCurrentUser}
+            >
+              {isDeletePending ? <Spinner className="size-3.5" /> : null}
+              Elimina utente
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Sheet>
   );
 }

--- a/apps/sm-fe-smcr/components/members/table/columns.tsx
+++ b/apps/sm-fe-smcr/components/members/table/columns.tsx
@@ -28,10 +28,6 @@ export const columns: ColumnDef<MemberWithTeams>[] = [
     size: 40,
   },
   {
-    accessorKey: "id",
-    header: "ID",
-  },
-  {
     accessorKey: "firstname",
     header: "Nome",
   },

--- a/apps/sm-fe-smcr/lib/actions/members.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/members.action.ts
@@ -4,6 +4,7 @@ import {
   createMemberTeam,
   removeMemberTeam,
 } from "@/lib/services/teams.service";
+import { deleteMemberById as deleteMemberByIdService } from "@/lib/services/members.service";
 import { validateFormData } from "@/lib/utils";
 import { revalidatePath } from "next/cache";
 import z from "zod";
@@ -18,9 +19,25 @@ const updateMemberTeamSchema = z.object({
 });
 type UpdateMemberTeamInput = z.infer<typeof updateMemberTeamSchema>;
 
+const deleteMemberSchema = z.object({
+  memberId: z.coerce.number().int().positive(),
+});
+
+type DeleteMemberInput = z.infer<typeof deleteMemberSchema>;
+
 export type UpdateMemberTeamFormState = {
   data: Partial<UpdateMemberTeamInput>;
   error?: { root?: string } | null;
+};
+
+export type DeleteMemberFormState = {
+  data: Partial<DeleteMemberInput>;
+  error: { root?: string } | null;
+};
+
+const initialDeleteMemberState: DeleteMemberFormState = {
+  data: {},
+  error: null,
 };
 
 export async function updateMemberTeamAction(
@@ -53,4 +70,38 @@ export async function updateMemberTeamAction(
   revalidatePath("/dashboard/members");
 
   return { data: { ...input, active: !input.active }, error: null };
+}
+
+export async function deleteMemberAction(
+  _prevState: DeleteMemberFormState = initialDeleteMemberState,
+  formData: FormData,
+): Promise<DeleteMemberFormState> {
+  const { input, errors } = validateFormData(deleteMemberSchema, formData);
+
+  if (errors) {
+    return { data: input, error: errors };
+  }
+
+  const deletedMember = await deleteMemberByIdService({
+    memberId: input.memberId,
+  });
+
+  if (deletedMember.error) {
+    return {
+      data: input,
+      error: {
+        root:
+          deletedMember.error === "not found"
+            ? "Utente non trovato."
+            : "Si è verificato un errore, riprova più tardi.",
+      },
+    };
+  }
+
+  revalidatePath("/dashboard/members");
+
+  return {
+    data: { memberId: deletedMember.data.id },
+    error: null,
+  };
 }

--- a/apps/sm-fe-smcr/lib/services/members.service.ts
+++ b/apps/sm-fe-smcr/lib/services/members.service.ts
@@ -19,6 +19,8 @@ const memberWithTeamsSchema = memberSchema.extend({
 });
 export type MemberWithTeams = z.infer<typeof memberWithTeamsSchema>;
 
+type MemberDeleteError = "not found" | "database error";
+
 export async function readMembers() {
   const rawMembers = await database.from("members").select("*");
   const members = z.array(memberSchema).safeParse(rawMembers);
@@ -89,6 +91,41 @@ export async function createMember(input: {
     return { data: member.data, error: null };
   } catch (error) {
     console.error("createMember - database error", error);
+    return { data: null, error: "database error" };
+  }
+}
+
+export async function deleteMemberById(input: {
+  memberId: number;
+}): Promise<
+  | { data: { id: number }; error: null }
+  | { data: null; error: MemberDeleteError }
+> {
+  try {
+    const deletedMemberId = await database.transaction(async (trx) => {
+      const existingMember = await trx
+        .from("members")
+        .select("id")
+        .where({ id: input.memberId })
+        .first();
+
+      if (!existingMember) {
+        return null;
+      }
+
+      await trx.from("member_teams").where({ memberId: input.memberId }).del();
+      await trx.from("members").where({ id: input.memberId }).del();
+
+      return input.memberId;
+    });
+
+    if (deletedMemberId === null) {
+      return { data: null, error: "not found" };
+    }
+
+    return { data: { id: deletedMemberId }, error: null };
+  } catch (error) {
+    console.error("deleteMemberById - database error", error);
     return { data: null, error: "database error" };
   }
 }


### PR DESCRIPTION
## Summary
- nasconde la colonna `ID` dalla tabella membri, dato che non viene usata nella lista
- aggiunge la hard delete del membro direttamente dal dettaglio nel `Sheet`, con dialog di conferma e feedback via toast
- rimuove in transazione anche le relazioni su `member_teams` e blocca la self-delete dell'utente loggato