### PR TITLE
[SMION-688] Route SMCR logs through structured logger

### DIFF
--- a/apps/sm-fe-smcr/actions/admin.ts
+++ b/apps/sm-fe-smcr/actions/admin.ts
@@ -36,7 +36,5 @@ export async function updateTeam(
   //   },
   // });
 
-  // console.log(response);
-
   return { data: team };
 }

--- a/apps/sm-fe-smcr/app/api/auth/callback/microsoft/route.tsx
+++ b/apps/sm-fe-smcr/app/api/auth/callback/microsoft/route.tsx
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server";
 import { getMsalInstance } from "@/lib/msalConfig";
 import { clientEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 export async function GET(request: Request) {
   try {
@@ -15,7 +16,7 @@ export async function GET(request: Request) {
       ),
     );
   } catch (error) {
-    console.error("Errore durante l'autenticazione:", error);
+    logServerError(error, "Errore durante l'autenticazione");
     return NextResponse.redirect(
       new URL(
         `${clientEnv.NEXT_PUBLIC_APP_URL}/auth/error?cause=callback`,
@@ -38,7 +39,7 @@ export async function GET(request: Request) {
 
 //     return NextResponse.redirect(`${origin}/dashboard`);
 //   } catch (error) {
-//     console.error("Errore durante l'autenticazione:", error);
+//     logServerError(error, "Errore durante l'autenticazione");
 //     const origin = new URL(request.url).origin;
 //     return NextResponse.redirect(`${origin}/auth/error?cause=callback`);
 //   }

--- a/apps/sm-fe-smcr/app/api/contract/download/route.ts
+++ b/apps/sm-fe-smcr/app/api/contract/download/route.ts
@@ -1,4 +1,5 @@
 import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -73,7 +74,7 @@ export async function GET(request: Request) {
       headers,
     });
   } catch (err) {
-    console.error("Errore interno nel proxy", err);
+    logServerError(err, "Errore interno nel proxy");
     return new Response(JSON.stringify({ error: "Errore interno nel proxy" }), {
       status: 500,
     });

--- a/apps/sm-fe-smcr/app/api/db-status/route.ts
+++ b/apps/sm-fe-smcr/app/api/db-status/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server";
 import pg from "@/lib/knex";
 import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 export async function GET() {
   try {
@@ -16,7 +17,7 @@ export async function GET() {
       { status: 200 },
     );
   } catch (error: any) {
-    console.error("❌ DB CONNECTION ERROR:", error.message);
+    logServerError(error, "DB connection error");
 
     return NextResponse.json(
       {

--- a/apps/sm-fe-smcr/app/api/monitoring/logs/route.ts
+++ b/apps/sm-fe-smcr/app/api/monitoring/logs/route.ts
@@ -17,9 +17,8 @@ export async function POST(request: Request) {
   const result = logInputSchema.safeParse(body);
 
   if (!result.success) {
-    console.warn(
-      "log validation error",
-      z.flattenError(result.error).fieldErrors,
+    process.stderr.write(
+      `log validation error: ${JSON.stringify(z.flattenError(result.error).fieldErrors)}\n`,
     );
     return Response.json(
       { message: z.flattenError(result.error).fieldErrors },

--- a/apps/sm-fe-smcr/app/api/teams/[teamId]/delete/route.ts
+++ b/apps/sm-fe-smcr/app/api/teams/[teamId]/delete/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import knex from "@/lib/knex";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function GET(
   req: NextRequest,
@@ -8,7 +12,7 @@ export async function GET(
 ) {
   try {
     const { teamId } = await params;
-    console.log("CANCELLOOOO", teamId);
+    logServerInfo("Delete team requested", { teamId });
 
     if (!teamId) {
       return NextResponse.json({ error: "Missing teamId" }, { status: 400 });
@@ -32,11 +36,11 @@ export async function GET(
     // Se il team non è "Admin", procedi con la cancellazione
     const result = await knex("team").where({ id: teamId }).del();
 
-    console.log("Delete team result:", result);
+    logServerInfo("Delete team result", { result });
 
     return NextResponse.json({ success: true });
   } catch (error: any) {
-    console.error("Errore API delete -team:", error);
+    logServerError(error, "Errore API delete team");
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/apps/sm-fe-smcr/app/api/teams/[teamId]/remove-user/route.ts
+++ b/apps/sm-fe-smcr/app/api/teams/[teamId]/remove-user/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import knex from "@/lib/knex";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function POST(
   req: NextRequest,
@@ -16,11 +20,11 @@ export async function POST(
 
     const result = await knex("member").where({ id: memberId }).del();
 
-    console.log("Delete result:", result);
+    logServerInfo("Delete member result", { result });
 
     return NextResponse.json({ success: true });
   } catch (error: any) {
-    console.error("Errore API remove-user:", error);
+    logServerError(error, "Errore API remove-user");
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/apps/sm-fe-smcr/app/api/teams/[teamId]/update-image/route.ts
+++ b/apps/sm-fe-smcr/app/api/teams/[teamId]/update-image/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import knex from "@/lib/knex";
 import sharp from "sharp";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 export async function POST(
   request: NextRequest,
@@ -11,7 +12,6 @@ export async function POST(
 
   const formData = await request.formData();
   const imageFile = formData.get("image") as File | null;
-  console.log(formData);
   if (!imageFile) {
     return NextResponse.json(
       { error: "File immagine mancante" },
@@ -43,7 +43,7 @@ export async function POST(
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error("Errore aggiornamento immagine team:", error);
+    logServerError(error, "Errore aggiornamento immagine team");
     return NextResponse.json({ error: "Errore interno" }, { status: 500 });
   }
 }

--- a/apps/sm-fe-smcr/app/api/teams/[teamId]/update-role/route.ts
+++ b/apps/sm-fe-smcr/app/api/teams/[teamId]/update-role/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import knex from "@/lib/knex";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function POST(
   req: NextRequest,
@@ -9,7 +13,7 @@ export async function POST(
   try {
     const { memberId, role } = await req.json();
     // const { teamId } = await params;
-    console.log("Received params:", { memberId, role }); // Debug
+    logServerInfo("Received update role params", { memberId, role });
 
     if (!memberId || !role) {
       return NextResponse.json(
@@ -18,17 +22,17 @@ export async function POST(
       );
     }
 
-    console.log(`UPDATE ROLE: id=${memberId}, role=${role}`);
+    logServerInfo("Update role requested", { memberId, role });
 
     const result = await knex("member")
       .where({ id: memberId })
       .update({ role });
 
-    console.log("Update result:", result);
+    logServerInfo("Update role result", { result });
 
     return NextResponse.json({ success: true });
   } catch (error: any) {
-    console.error("Errore API update-role:", error);
+    logServerError(error, "Errore API update-role");
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/apps/sm-fe-smcr/app/api/teams/list/route.ts
+++ b/apps/sm-fe-smcr/app/api/teams/list/route.ts
@@ -1,14 +1,18 @@
 import { NextResponse } from "next/server";
 import pg from "@/lib/knex";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function GET() {
   try {
-    console.log("CALLING API LIST TEAMS");
+    logServerInfo("CALLING API LIST TEAMS");
     const teams = await pg.select().table("team");
 
     return NextResponse.json(teams, { status: 200 });
   } catch (error) {
-    console.error("Errore API team:", error);
+    logServerError(error, "Errore API team");
     return NextResponse.json(
       { error: "Errore interno del server" },
       { status: 500 },

--- a/apps/sm-fe-smcr/app/api/teams/new/route.ts
+++ b/apps/sm-fe-smcr/app/api/teams/new/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import pg from "@/lib/knex";
 import { randomUUID } from "crypto";
 import sharp from "sharp";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 export const config = {
   api: {
@@ -46,7 +47,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ data: team }, { status: 201 });
   } catch (error) {
-    console.error("Errore API team:", error);
+    logServerError(error, "Errore API team");
     return NextResponse.json(
       { error: "Errore interno del server" },
       { status: 500 },

--- a/apps/sm-fe-smcr/app/api/teams/route.ts
+++ b/apps/sm-fe-smcr/app/api/teams/route.ts
@@ -3,9 +3,7 @@
 // import { randomUUID } from "crypto";
 // export async function POST(request: NextRequest) {
 //   try {
-//     console.log('GET TEAMS')
 //     const body = await request.json();
-//     console.log(body);
 //     const { name, email } = body;
 
 //     // Query database
@@ -28,7 +26,6 @@
 
 //     return NextResponse.json({ data: result[0] });
 //   } catch (error) {
-//     console.error("Errore API profile:", error);
 //     return NextResponse.json(
 //       { error: "Errore interno del server" },
 //       { status: 500 },

--- a/apps/sm-fe-smcr/app/api/user/list/route.ts
+++ b/apps/sm-fe-smcr/app/api/user/list/route.ts
@@ -1,14 +1,18 @@
 import { NextResponse } from "next/server";
 import pg from "@/lib/knex";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function GET() {
   try {
-    console.log("CALLING API LIST USERS");
+    logServerInfo("CALLING API LIST USERS");
     const users = await pg.select().table("user");
 
     return NextResponse.json(users, { status: 200 });
   } catch (error) {
-    console.error("Errore API LIST user:", error);
+    logServerError(error, "Errore API LIST user");
     return NextResponse.json(
       { error: "Errore interno del server" },
       { status: 500 },

--- a/apps/sm-fe-smcr/app/api/user/preferences/route.ts
+++ b/apps/sm-fe-smcr/app/api/user/preferences/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import knex from "@/lib/knex";
 import { randomUUID } from "crypto";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function GET(request: NextRequest) {
   try {
@@ -30,7 +34,7 @@ export async function GET(request: NextRequest) {
     }
     return NextResponse.json(preferences[0], { status: 200 });
   } catch (error) {
-    console.error("Errore API get preferences:", error);
+    logServerError(error, "Errore API get preferences");
     return NextResponse.json(
       { error: `Errore interno del server ${error}` },
       { status: 500 },
@@ -50,8 +54,7 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    // Log utile per debug
-    console.log("Aggiornamento preferenze:", { userId, teamId, theme });
+    logServerInfo("Aggiornamento preferenze", { userId, teamId, theme });
 
     // Esegui UPDATE con await
     const result = await knex("preferences")
@@ -73,7 +76,7 @@ export async function PATCH(request: NextRequest) {
 
     return NextResponse.json({ status: 200, updated: result[0] });
   } catch (error) {
-    console.error("Errore API PATCH /user/preferences:", error);
+    logServerError(error, "Errore API PATCH /user/preferences");
     return NextResponse.json(
       { error: "Errore interno del server" },
       { status: 500 },

--- a/apps/sm-fe-smcr/app/api/user/profile/route.ts
+++ b/apps/sm-fe-smcr/app/api/user/profile/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import pg from "@/lib/knex";
 import { randomUUID } from "crypto";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 export async function POST(request: NextRequest) {
   try {
@@ -30,7 +31,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ data: result[0] });
   } catch (error) {
-    console.error("Errore API profile:", error);
+    logServerError(error, "Errore API profile");
     return NextResponse.json(
       { error: "Errore interno del server" },
       { status: 500 },
@@ -64,7 +65,7 @@ export async function POST(request: NextRequest) {
 
 //     res.json(user);
 //   } catch (error) {
-//     console.error("Errore API profile:", error);
+//     logServerError(error, "Errore API profile");
 //     res.status(500).json({ error: "Errore interno del server" });
 //   }
 // }

--- a/apps/sm-fe-smcr/app/api/user/teams/route.ts
+++ b/apps/sm-fe-smcr/app/api/user/teams/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import pg from "@/lib/knex";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 export async function GET(request: NextRequest) {
   try {
@@ -43,7 +44,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(getUserWithTeamsByEmail, { status: 200 });
   } catch (error) {
-    console.error("Errore API user team:", error);
+    logServerError(error, "Errore API user team");
     return NextResponse.json(
       { error: "Errore interno del server" },
       { status: 500 },

--- a/apps/sm-fe-smcr/app/dashboard/account/page.tsx
+++ b/apps/sm-fe-smcr/app/dashboard/account/page.tsx
@@ -25,19 +25,12 @@ export default function AccountProfilePage() {
 
   useEffect(() => {
     if (user) {
-      console.log("PREFERENZE");
-      console.log(user);
-
       setSelectedTeamId(user.preferences.teamId);
       setSelectedTheme(user.preferences.theme);
     }
   }, [user]);
 
   const handleUpdatePreferences = () => {
-    console.log("Salvataggio preferences:", {
-      teamId: selectedTeamId,
-      theme: selectedTheme,
-    });
     if (user) {
       postUserPreferences(user.id, {
         teamId: selectedTeamId,

--- a/apps/sm-fe-smcr/app/dashboard/ask-me-anything/page.tsx
+++ b/apps/sm-fe-smcr/app/dashboard/ask-me-anything/page.tsx
@@ -5,13 +5,14 @@ import {
   AskMeAnythingTableSection,
 } from "@/components/ask-me-anything";
 import { readAskMeAnythingMembers } from "@/lib/services/ask-me-anything.service";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 import { UsersIcon } from "lucide-react";
 
 export default async function AskMeAnythingPage() {
   const { data, error } = await readAskMeAnythingMembers();
 
   if (error) {
-    console.error("AskMeAnythingPage - read error", error);
+    logServerError(error, "AskMeAnythingPage - read error");
   }
 
   return (

--- a/apps/sm-fe-smcr/app/dashboard/members/page.tsx
+++ b/apps/sm-fe-smcr/app/dashboard/members/page.tsx
@@ -5,18 +5,19 @@ import { columns, MembersTable } from "@/components/members/table";
 import TeamsStoreDispatcher from "@/components/teams/teams-store-dispatcher";
 import { readMembers } from "@/lib/services/members.service";
 import { readTeams } from "@/lib/services/teams.service";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 import { UsersIcon } from "lucide-react";
 
 export default async function Page() {
   const members = await readMembers();
   if (members.error || members.data === null) {
-    console.error(members.error);
+    logServerError(members.error, "Members page - read members error");
     throw new Error(members.error);
   }
 
   const teams = await readTeams();
   if (teams.error || teams.data === null) {
-    console.error(teams.error);
+    logServerError(teams.error, "Members page - read teams error");
     throw new Error(teams.error);
   }
 

--- a/apps/sm-fe-smcr/app/dashboard/teams/page.tsx
+++ b/apps/sm-fe-smcr/app/dashboard/teams/page.tsx
@@ -8,6 +8,7 @@ import {
   readTeamMemberCounts,
   readTeams,
 } from "@/lib/services/teams.service";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 import { UsersIcon } from "lucide-react";
 
 export default async function Page() {
@@ -18,17 +19,17 @@ export default async function Page() {
   ]);
 
   if (teams.error || teams.data === null) {
-    console.error(teams.error);
+    logServerError(teams.error, "Teams page - read teams error");
     throw new Error(teams.error);
   }
 
   if (features.error || features.data === null) {
-    console.error(features.error);
+    logServerError(features.error, "Teams page - read features error");
     throw new Error(features.error);
   }
 
   if (teamMemberCounts.error || teamMemberCounts.data === null) {
-    console.error(teamMemberCounts.error);
+    logServerError(teamMemberCounts.error, "Teams page - read member counts error");
     throw new Error(teamMemberCounts.error);
   }
 

--- a/apps/sm-fe-smcr/app/onboarding/page.tsx
+++ b/apps/sm-fe-smcr/app/onboarding/page.tsx
@@ -1,4 +1,5 @@
 import { readTeams } from "@/lib/services/teams.service";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 import RequestAccessForm, { TeamSelectOption } from "./request-access-form";
 
 export const dynamic = "force-dynamic";
@@ -7,7 +8,7 @@ export default async function Page() {
   const teamsResult = await readTeams();
 
   if (teamsResult.error || teamsResult.data === null) {
-    console.error("Unable to load teams for onboarding", teamsResult.error);
+    logServerError(teamsResult.error, "Unable to load teams for onboarding");
     return <RequestAccessForm teamOptions={[]} />;
   }
 

--- a/apps/sm-fe-smcr/components/admin/teams/team-member-list.tsx
+++ b/apps/sm-fe-smcr/components/admin/teams/team-member-list.tsx
@@ -10,6 +10,7 @@ import { TEAM_ROLES } from "@/lib/costants";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import clientLogger from "@/lib/logger/logger.client";
 
 type Member = {
   id: string;
@@ -57,7 +58,7 @@ export default function TeamMemberList({ teamId, members, onUpdate }: Props) {
           description: "Si è verificato un problema. Riprova più tardi.",
           duration: 4000,
         });
-        console.error("Errore rimozione utente:", error);
+        void clientLogger.error({ error }, "Errore rimozione utente");
       } finally {
         setLoading(null);
       }
@@ -92,7 +93,7 @@ export default function TeamMemberList({ teamId, members, onUpdate }: Props) {
           description: "Si è verificato un problema. Riprova più tardi.",
           duration: 4000,
         });
-        console.error("Errore aggiornamento ruolo:", error);
+        void clientLogger.error({ error }, "Errore aggiornamento ruolo");
       } finally {
         setLoading(null);
       }

--- a/apps/sm-fe-smcr/components/admin/teams/update-team-image.tsx
+++ b/apps/sm-fe-smcr/components/admin/teams/update-team-image.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import ImageTeam from "@/components/admin/teams/image-teams";
 import { useRouter } from "next/navigation";
 import { clientEnv } from "@/config/env";
+import clientLogger from "@/lib/logger/logger.client";
 
 const baseUrl = clientEnv.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -45,9 +46,9 @@ export default function UpdateTeamImage({ teamId }: { teamId: string }) {
 
       router.refresh();
     } catch (error) {
-      console.error(
-        "Errore durante l'aggiornamento dell'immagine del team:",
-        error,
+      void clientLogger.error(
+        { error },
+        "Errore durante l'aggiornamento dell'immagine del team",
       );
     } finally {
       setIsLoading(false);
@@ -73,7 +74,7 @@ export default function UpdateTeamImage({ teamId }: { teamId: string }) {
           }
         }}
         onError={(error) => {
-          console.error(error);
+          void clientLogger.error({ error }, "Errore selezione immagine team");
           setIsWorkingPreview(false);
         }}
       />

--- a/apps/sm-fe-smcr/components/auth/clientPageGuard.tsx
+++ b/apps/sm-fe-smcr/components/auth/clientPageGuard.tsx
@@ -7,6 +7,7 @@ import { Loader } from "../loader";
 import { useRouteAccess } from "@/hooks/useRouteAccess";
 import useAuthStore from "@/lib/store/auth.store";
 import { readMemberByEmail } from "@/lib/services/members.service";
+import clientLogger from "@/lib/logger/logger.client";
 
 export default function ClientPageGuard({
   children,
@@ -51,13 +52,21 @@ export default function ClientPageGuard({
       hasRedirected.current = true;
 
       if (reason === "not_authenticated") {
-        console.warn("Accesso negato: utente non autenticato", { pathname });
+        void clientLogger.warn(
+          { info: { event: "access.denied", metadata: { pathname, reason } } },
+          "Accesso negato: utente non autenticato",
+        );
         router.replace("/unauthorized");
       } else {
-        console.warn("Accesso negato: permessi insufficienti", {
-          user: user?.email,
-          pathname,
-        });
+        void clientLogger.warn(
+          {
+            info: {
+              event: "access.denied",
+              metadata: { user: user?.email, pathname, reason },
+            },
+          },
+          "Accesso negato: permessi insufficienti",
+        );
         router.replace("/dashboard");
       }
     }

--- a/apps/sm-fe-smcr/components/auth/login/login.tsx
+++ b/apps/sm-fe-smcr/components/auth/login/login.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useMsal } from "@azure/msal-react";
 import { loginRequest } from "@/lib/msalConfig";
+import clientLogger from "@/lib/logger/logger.client";
 
 export const LoginForm = () => {
   return (
@@ -21,7 +22,7 @@ export const MicrosoftLoginButton = () => {
     // };
 
     instance.loginRedirect(loginRequest).catch((error) => {
-      console.error("Login error:", error);
+      void clientLogger.error({ error }, "Login error");
     });
   };
 

--- a/apps/sm-fe-smcr/components/call-management/crm-form.tsx
+++ b/apps/sm-fe-smcr/components/call-management/crm-form.tsx
@@ -139,7 +139,6 @@ export default function CRMForm() {
       enableGrantAccess: values.enableGrantAccess,
       dryRun: values.dryRun,
     };
-    console.log("payLoad", payLoad);
     const result = await createMeetingAction(payLoad);
 
     if (result.success) {

--- a/apps/sm-fe-smcr/components/layout/nav-header.tsx
+++ b/apps/sm-fe-smcr/components/layout/nav-header.tsx
@@ -94,7 +94,6 @@ export function NavHeader({ members }: { members: Array<Member> | undefined }) {
                 <DropdownMenuItem
                   key={member.team.name}
                   onClick={() => {
-                    console.log("ACTIVE TEAM IN SETTING", member.team);
                     setActiveTeam(member.team);
 
                     if (user) {

--- a/apps/sm-fe-smcr/components/layout/sidebar/sidebar-header.tsx
+++ b/apps/sm-fe-smcr/components/layout/sidebar/sidebar-header.tsx
@@ -87,7 +87,6 @@ export function TeamSwitcher({}: {}) {
                 <DropdownMenuItem
                   key={member.team.name}
                   onClick={() => {
-                    console.log("ACTIVE TEAM IN SETTING", member.team);
                     setActiveTeam(member.team);
 
                     if (user) {

--- a/apps/sm-fe-smcr/components/login/login-page.tsx
+++ b/apps/sm-fe-smcr/components/login/login-page.tsx
@@ -6,6 +6,7 @@ import { LoginForm } from "../auth/login";
 import { Switch } from "../ui/switch";
 import { useEffect, useState } from "react";
 import { clientEnv } from "@/config/env";
+import clientLogger from "@/lib/logger/logger.client";
 
 export const LoginPage = () => {
   const redirectURL = clientEnv.NEXT_PUBLIC_APP_URL;
@@ -24,7 +25,7 @@ export const LoginPage = () => {
         setDbStatus(json.status === "online" ? "online" : "error");
       } catch (err) {
         setDbStatus("error");
-        console.error(err);
+        void clientLogger.error({ error: err }, "DB status check failed");
       }
     }
 

--- a/apps/sm-fe-smcr/components/provisioning/members/columns.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/members/columns.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect, useRef, useTransition } from "react";
+import { useActionState, useRef, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -69,10 +69,6 @@ export const getColumns: (
           });
         }
       }
-
-      useEffect(() => {
-        console.log({ state, isPending });
-      }, [state, isPending]);
 
       return (
         <form action={action} ref={ref}>

--- a/apps/sm-fe-smcr/components/provisioning/product/contract/contract-tab.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/product/contract/contract-tab.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { BadgeCheckIcon } from "lucide-react";
 import DownloadConctract from "./download-contract";
 import SendToQueue from "./send-to-queue";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 type Props = {
   institution: string;
@@ -23,7 +24,7 @@ export default async function ContractTab({
   const hasContract = await verifyContract(onboarding);
 
   if (groups.error || !groups.data) {
-    console.error(groups);
+    logServerError(groups.error, "ContractTab - read groups error", groups);
     throw new Error(groups.error || "Errore imprevisto");
   }
 

--- a/apps/sm-fe-smcr/components/provisioning/product/delegations/add-delegation.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/product/delegations/add-delegation.tsx
@@ -17,6 +17,7 @@ import {
   FieldSet,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import clientLogger from "@/lib/logger/logger.client";
 import {
   InputGroup,
   InputGroupAddon,
@@ -111,7 +112,7 @@ export default function AddDelegation({
           setInstitutionTo(data.at(0) || null);
         })
         .catch((error) => {
-          console.error(error);
+          void clientLogger.error({ error }, "addDelegation - institution lookup error");
           setTaxCodeToError("Si è verificato un errore, riprova più tardi.");
           setInstitutionTo(null);
           setInstitutionOptions([]);

--- a/apps/sm-fe-smcr/components/provisioning/product/groups/groups-tab.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/product/groups/groups-tab.tsx
@@ -1,4 +1,5 @@
 import { getUserGroups } from "@/lib/services/institution.service";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 import { DataTable } from "./table";
 import { columns } from "./table/columns";
 
@@ -11,7 +12,7 @@ export default async function GroupsTab({ institution, product }: Props) {
   const groups = await getUserGroups({ institution });
 
   if (groups.error || !groups.data) {
-    console.error(groups);
+    logServerError(groups.error, "GroupsTab - read groups error", groups);
     throw new Error(groups.error || "Errore imprevisto");
   }
 

--- a/apps/sm-fe-smcr/components/provisioning/product/users/user-dialog.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/product/users/user-dialog.tsx
@@ -12,6 +12,7 @@ import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { EyeIcon, EyeOffIcon, UserIcon } from "lucide-react";
 import { useEffect, useState } from "react";
+import clientLogger from "@/lib/logger/logger.client";
 
 type Props = {
   children: React.ReactNode;
@@ -26,7 +27,7 @@ export default function UserDialog({ children, institutionId, userId }: Props) {
   const fetchUser = async () => {
     const { data, error } = await readUser({ institutionId, userId });
     if (error) {
-      console.error(error);
+      void clientLogger.error({ error }, "UserDialog - read user error");
       return;
     }
 

--- a/apps/sm-fe-smcr/components/provisioning/search/form.tsx
+++ b/apps/sm-fe-smcr/components/provisioning/search/form.tsx
@@ -29,8 +29,6 @@ export default function SearchInstitution({
           event.preventDefault();
           if (isPNPG) router.push(`/dashboard/pnpg/${query.trim()}`);
           else router.push(`/dashboard/overview/${query.trim()}`);
-
-          console.log("submit", query);
         }}
       >
         <Input

--- a/apps/sm-fe-smcr/config/env.ts
+++ b/apps/sm-fe-smcr/config/env.ts
@@ -134,18 +134,16 @@ const rawClientEnv = {
 
 const serverEnvParse = serverEnvSchema.safeParse(rawServerEnv);
 if (!serverEnvParse.success) {
-  console.error(
-    "Invalid server env configuration:",
-    serverEnvParse.error.issues,
+  process.stderr.write(
+    `Invalid server env configuration: ${JSON.stringify(serverEnvParse.error.issues)}\n`,
   );
   throw new Error("Invalid server env configuration");
 }
 
 const clientEnvParse = clientEnvSchema.safeParse(rawClientEnv);
 if (!clientEnvParse.success) {
-  console.error(
-    "Invalid client env configuration:",
-    clientEnvParse.error.issues,
+  process.stderr.write(
+    `Invalid client env configuration: ${JSON.stringify(clientEnvParse.error.issues)}\n`,
   );
   throw new Error("Invalid client env configuration");
 }

--- a/apps/sm-fe-smcr/context/MSALproviders.tsx
+++ b/apps/sm-fe-smcr/context/MSALproviders.tsx
@@ -2,6 +2,7 @@
 import { MsalProvider } from "@azure/msal-react";
 import { useEffect, useState } from "react";
 import { getMsalInstance } from "@/lib/msalConfig";
+import clientLogger from "@/lib/logger/logger.client";
 
 export function MSALProvider({ children }: { children: React.ReactNode }) {
   const [, setInitialized] = useState(false);
@@ -10,7 +11,9 @@ export function MSALProvider({ children }: { children: React.ReactNode }) {
     getMsalInstance()
       .initialize()
       .then(() => setInitialized(true))
-      .catch(console.error);
+      .catch((error) => {
+        void clientLogger.error({ error }, "MSAL initialize failed");
+      });
   }, []);
 
   return <MsalProvider instance={getMsalInstance()}>{children}</MsalProvider>;

--- a/apps/sm-fe-smcr/context/sessionProvider.tsx
+++ b/apps/sm-fe-smcr/context/sessionProvider.tsx
@@ -15,6 +15,7 @@ import {
   readMemberByEmail,
   createMember,
 } from "@/lib/services/members.service";
+import clientLogger from "@/lib/logger/logger.client";
 
 interface SessionContextType {
   user: UserProfile | null;
@@ -88,10 +89,14 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       // Check if member exists in the new members table, create if not
       const memberResult = await readMemberByEmail(msalAccount.username);
       if (memberResult.error || !memberResult.data) {
-        // Member doesn't exist - create one
-        console.log(
-          "Member not found, creating new member for:",
-          msalAccount.username,
+        void clientLogger.info(
+          {
+            info: {
+              event: "session.member.create_missing",
+              metadata: { email: msalAccount.username },
+            },
+          },
+          "Member not found, creating new member",
         );
 
         // Extract firstname and lastname from MSAL claims or parse from name
@@ -111,9 +116,12 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         });
 
         if (createResult.error) {
-          console.error("Failed to create member:", createResult.error);
+          void clientLogger.error(
+            { error: createResult.error },
+            "Failed to create member",
+          );
         } else {
-          console.log("Member created successfully:", createResult.data);
+          void clientLogger.info("Member created successfully");
         }
       }
 
@@ -132,7 +140,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         },
       });
     } catch (err: any) {
-      console.error("Errore caricamento profilo:", err);
+      void clientLogger.error({ error: err }, "Errore caricamento profilo");
       setError(err.message || "Errore sconosciuto");
       setUser(null);
     } finally {
@@ -146,7 +154,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       setUser(null);
       await instance.logoutRedirect();
     } catch (err: any) {
-      console.error("Errore durante il logout:", err);
+      void clientLogger.error({ error: err }, "Errore durante il logout");
       setError(err.message);
     }
   }, [instance]);
@@ -164,7 +172,6 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const handleStorageChange = (e: StorageEvent) => {
       if (e.key?.includes("msal")) {
-        console.log("MSAL storage changed, refreshing user data");
         refreshUserData();
       }
     };

--- a/apps/sm-fe-smcr/features/core/SideNav.tsx
+++ b/apps/sm-fe-smcr/features/core/SideNav.tsx
@@ -121,7 +121,6 @@
 //   active: boolean;
 //   isSidebarExpanded: boolean;
 // }> = ({ name, label, icon, path, active, isSidebarExpanded }) => {
-//   console.log(label);
 //   return (
 //     <>
 //       {isSidebarExpanded ? (

--- a/apps/sm-fe-smcr/features/onboarding/actions/getOnboardingStatus.ts
+++ b/apps/sm-fe-smcr/features/onboarding/actions/getOnboardingStatus.ts
@@ -11,13 +11,15 @@ import {
   GET_STATUS,
   ONBOARDING_BASE_PATH,
 } from "./config/env";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function onboardingStatus(
   state: StatusActionState,
   formData: FormData,
 ): Promise<StatusActionState> {
-  console.log("Server Action - FormData entries:");
-  formData.forEach((value, key) => console.log(key, value));
   const subunit = formData.get("subunit") as SubunitOption;
 
   const isSubunit = subunit === "AOO" || subunit === "UO";
@@ -32,10 +34,9 @@ export async function onboardingStatus(
 
   try {
     const { error: parseError } = statusSchema.safeParse(values);
-    console.log(
-      parseError,
-      `${GET_STATUS}?taxcode=${values.taxcode}${isSubunit ? `&subunitCode=${values.subunitCode}` : ""}`,
-    );
+    if (parseError) {
+      logServerError(parseError, "onboardingStatus - validation error");
+    }
     if (parseError) {
       const errors: StatusActionState["validationErrors"] = {};
       for (const { path, message } of parseError?.issues ?? []) {
@@ -48,7 +49,7 @@ export async function onboardingStatus(
       };
     }
   } catch (parseError) {
-    console.log(parseError);
+    logServerError(parseError, "onboardingStatus - parse error");
     if (parseError instanceof z.ZodError) {
       const errors: StatusActionState["validationErrors"] = {};
       for (const { path, message } of parseError?.issues ?? []) {
@@ -88,7 +89,7 @@ export async function onboardingStatus(
           },
         };
       } else {
-        console.log(error);
+        logServerError(error, "onboardingStatus - fetch error");
         return {
           formValues: values,
           validationErrors: {},
@@ -114,7 +115,7 @@ export async function onboardingStatus(
         },
       };
     }
-    console.log("DATA: ", data);
+    logServerInfo("onboardingStatus - data retrieved", { count: data.length });
 
     const product = data.find(
       (product) => product.productId === values.productId,
@@ -148,7 +149,7 @@ export async function onboardingStatus(
       },
     };
   } catch (error) {
-    console.log(error);
+    logServerError(error, "onboardingStatus - unexpected error");
     return {
       formValues: values,
       validationErrors: {},

--- a/apps/sm-fe-smcr/features/onboarding/actions/getUserTaxCode.ts
+++ b/apps/sm-fe-smcr/features/onboarding/actions/getUserTaxCode.ts
@@ -8,6 +8,10 @@ import {
   GET_USERS_PATH,
   ONBOARDING_BASE_PATH,
 } from "./config/env";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function getUserTaxCode(state: any, formData: FormData) {
   const taxCodeFormData = formData.get("taxCode") as string;
@@ -47,14 +51,14 @@ export async function getUserTaxCode(state: any, formData: FormData) {
           message: "Utente non trovato",
         };
       } else {
-        console.log(error);
+        logServerError(error, "getUserTaxCode - fetch error");
         throw new Error();
       }
     }
-    console.log(data);
+    logServerInfo("getUserTaxCode - user retrieved", { taxCode });
     return { success: true, taxCode, data: data.user };
   } catch (error) {
-    console.log(error);
+    logServerError(error, "getUserTaxCode - unexpected error");
     return {
       success: false,
       taxCode,

--- a/apps/sm-fe-smcr/features/onboarding/actions/setDeleteStatus.ts
+++ b/apps/sm-fe-smcr/features/onboarding/actions/setDeleteStatus.ts
@@ -2,6 +2,10 @@
 
 import { $fetch } from "@/lib/fetch";
 import { FE_SMCR_OCP_APIM_SUBSCRIPTION_KEY, UPLOAD } from "./config/env";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function setDeleteStatus(state: any, formData: FormData) {
   const id = formData.get("id") as string;
@@ -36,13 +40,13 @@ export async function setDeleteStatus(state: any, formData: FormData) {
         message: error.message,
       };
     }
-    console.log(data);
+    logServerInfo("setDeleteStatus - onboarding deleted", { id, data });
 
     return {
       success: true,
     };
   } catch (error) {
-    console.error(error);
+    logServerError(error, "setDeleteStatus - unexpected error");
     return {
       success: false,
       message: "Qualcosa è andato storto",

--- a/apps/sm-fe-smcr/features/onboarding/actions/verifyTaxCode.ts
+++ b/apps/sm-fe-smcr/features/onboarding/actions/verifyTaxCode.ts
@@ -30,10 +30,14 @@ import {
   GET_STATUS,
   ONBOARDING_BASE_PATH,
 } from "./config/env";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export async function verifyTaxCode(state: any, formData: FormData) {
   const subunit = formData.get("subunitOption") as SubunitOption;
-  console.log({ subunit });
+  logServerInfo("verifyTaxCode - subunit selected", { subunit });
   let codeToSearch = "";
 
   switch (subunit) {
@@ -132,7 +136,10 @@ export async function verifyTaxCode(state: any, formData: FormData) {
       },
       output: schema,
     });
-    console.log({ data, error });
+    logServerInfo("verifyTaxCode - institution fetch completed", {
+      hasData: Boolean(data),
+      hasError: Boolean(error),
+    });
 
     if (error) {
       if (error.status === 404) {
@@ -142,7 +149,7 @@ export async function verifyTaxCode(state: any, formData: FormData) {
           message: "Ente non trovato",
         };
       } else {
-        console.log(error);
+        logServerError(error, "verifyTaxCode - institution fetch error");
         return {
           success: false,
           code: codeToSearch,
@@ -158,7 +165,6 @@ export async function verifyTaxCode(state: any, formData: FormData) {
         message: "Dati non trovati",
       };
     }
-    console.log(data);
     if (isIpaAOOData(data, subunit) || isIpaUOData(data, subunit)) {
       const subunitCode = formData.get("subunitCode") as string;
       try {
@@ -181,7 +187,7 @@ export async function verifyTaxCode(state: any, formData: FormData) {
               message: `GetInstitution è andata a buon fine ma GetOnboardingStatus ha dato il seguente errore: ${errorStatus.statusText}`,
             };
           } else {
-            console.log(errorStatus);
+            logServerError(errorStatus, "verifyTaxCode - subunit status error");
             return {
               success: false,
               code: codeToSearch,
@@ -212,8 +218,9 @@ export async function verifyTaxCode(state: any, formData: FormData) {
           .filter((el) =>
             (productKeys as unknown as string).includes(el.product),
           );
-        console.log("verifyTaxCode");
-        console.log({ dataTable });
+        logServerInfo("verifyTaxCode - subunit status data mapped", {
+          count: dataTable?.length ?? 0,
+        });
 
         return {
           success: true,
@@ -224,7 +231,7 @@ export async function verifyTaxCode(state: any, formData: FormData) {
           dataStatus: dataTable,
         };
       } catch (error) {
-        console.log(error);
+        logServerError(error, "verifyTaxCode - subunit status unexpected error");
         return {
           success: false,
           code: codeToSearch,
@@ -252,7 +259,7 @@ export async function verifyTaxCode(state: any, formData: FormData) {
               message: `GetInstitution è andata a buon fine ma GetOnboardingStatus ha dato il seguente errore: ${errorStatus.statusText}`,
             };
           } else {
-            console.log(errorStatus);
+            logServerError(errorStatus, "verifyTaxCode - status error");
             return {
               success: false,
               code: codeToSearch,
@@ -283,8 +290,9 @@ export async function verifyTaxCode(state: any, formData: FormData) {
           .filter((el) =>
             (productKeys as unknown as string).includes(el.product),
           );
-        console.log("verifyTaxCode");
-        console.log({ dataTable });
+        logServerInfo("verifyTaxCode - status data mapped", {
+          count: dataTable?.length ?? 0,
+        });
         return {
           success: true,
           code: codeToSearch,
@@ -294,7 +302,7 @@ export async function verifyTaxCode(state: any, formData: FormData) {
           dataStatus: dataTable,
         };
       } catch (error) {
-        console.log(error);
+        logServerError(error, "verifyTaxCode - status unexpected error");
         return {
           success: false,
           code: codeToSearch,
@@ -303,7 +311,7 @@ export async function verifyTaxCode(state: any, formData: FormData) {
       }
     }
   } catch (error) {
-    console.log(error);
+    logServerError(error, "verifyTaxCode - unexpected error");
     return {
       success: false,
       code: codeToSearch,

--- a/apps/sm-fe-smcr/features/onboarding/components/SearchSignerID.tsx
+++ b/apps/sm-fe-smcr/features/onboarding/components/SearchSignerID.tsx
@@ -8,6 +8,7 @@ import {
   FormLabel,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import clientLogger from "@/lib/logger/logger.client";
 import { SignIDFormSchema } from "@/lib/services/firma-con-io.schema";
 import { getFirmaConIoSignerID } from "@/lib/services/firma-con-io.service";
 import { CheckIcon, ClipboardIcon, CornerDownLeft } from "lucide-react";
@@ -57,7 +58,10 @@ export function SearchSignerID() {
             }
             const result = await getFirmaConIoSignerID(formData);
             if (result?.error) {
-              console.error(result?.error);
+              void clientLogger.error(
+                { error: result.error },
+                "SearchSignerID - signer lookup error",
+              );
               toast.error(
                 errorMessages[result?.error as keyof typeof errorMessages] ||
                   errorMessages.default,

--- a/apps/sm-fe-smcr/features/pda/components/TaxcodeList.tsx
+++ b/apps/sm-fe-smcr/features/pda/components/TaxcodeList.tsx
@@ -29,7 +29,6 @@ export function TaxcodeList({ data }: Props) {
   const [taxcode, setTaxcode] = useState<string>("");
 
   function createDb(data: Array<Ente>) {
-    console.log("🚀 ~ createDb ~");
     const trie = new Trie();
     for (const el of data) {
       trie.insert(el.codiceFiscale, {

--- a/apps/sm-fe-smcr/features/pda/lib/Trie.ts
+++ b/apps/sm-fe-smcr/features/pda/lib/Trie.ts
@@ -112,7 +112,6 @@ export default class Trie {
   print(node = this.root) {
     const currentNode = node;
     for (const [key, childNode] of currentNode.children) {
-      console.log(key);
       if (key !== "*" && childNode && isTrieNode(childNode)) {
         this.print(childNode);
       }

--- a/apps/sm-fe-smcr/hooks/use-live-logs.ts
+++ b/apps/sm-fe-smcr/hooks/use-live-logs.ts
@@ -2,6 +2,7 @@
 
 import { Log } from "@/lib/services/logs.service";
 import React, { useEffect } from "react";
+import clientLogger from "@/lib/logger/logger.client";
 
 function normalizeLog(
   input: Partial<Log> & { request?: string | null },
@@ -45,7 +46,7 @@ export function useLiveLogs(initialData: Array<Log>) {
 
         setData((prev) => [log, ...prev]);
       } catch (error) {
-        console.error(error);
+        void clientLogger.error({ error }, "Failed to parse live log event");
       }
     };
 

--- a/apps/sm-fe-smcr/hooks/useClipboard.tsx
+++ b/apps/sm-fe-smcr/hooks/useClipboard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import clientLogger from "@/lib/logger/logger.client";
 
 const useClipboard = () => {
   const [isCopied, setIsCopied] = useState(false);
@@ -20,7 +21,7 @@ const useClipboard = () => {
       setTimeout(() => setIsCopied(false), 2000);
       return true;
     } catch (err) {
-      console.error("Failed to copy text: ", err);
+      void clientLogger.error({ error: err }, "Failed to copy text");
       return false;
     }
   };

--- a/apps/sm-fe-smcr/lib/actions/ask-me-anything.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/ask-me-anything.action.ts
@@ -8,6 +8,7 @@ import {
 import { validateFormData } from "@/lib/utils";
 import { revalidatePath } from "next/cache";
 import z from "zod";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const booleanField = z.preprocess(
   (value) => value === "on" || value === "true" || value === true,
@@ -59,7 +60,7 @@ export async function createAskMeAnythingMemberAction(
 
   const result = await createAskMeAnythingMember(input);
   if (result.error) {
-    console.error("createAskMeAnythingMemberAction - error", result.error);
+    logServerError(result.error, "createAskMeAnythingMemberAction - error");
     return {
       data: input,
       error: {
@@ -89,7 +90,7 @@ export async function updateAskMeAnythingMemberAction(
 
   const result = await updateAskMeAnythingMember(input);
   if (result.error) {
-    console.error("updateAskMeAnythingMemberAction - error", result.error);
+    logServerError(result.error, "updateAskMeAnythingMemberAction - error");
     return {
       data: input,
       error: {
@@ -119,7 +120,7 @@ export async function deleteAskMeAnythingMemberAction(
 
   const result = await deleteAskMeAnythingMember(input);
   if (result.error) {
-    console.error("deleteAskMeAnythingMemberAction - error", result.error);
+    logServerError(result.error, "deleteAskMeAnythingMemberAction - error");
     return {
       data: input,
       error: {

--- a/apps/sm-fe-smcr/lib/actions/call-management.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/call-management.action.ts
@@ -290,7 +290,10 @@ export type CreateMeetingResult =
 export async function createMeetingAction(
   input: CreateMeetingInput,
 ): Promise<CreateMeetingResult> {
-  console.log("input", input);
+  logger.info(
+    { info: { event: "call-management.create-meeting", metadata: input } },
+    "Create meeting input received",
+  );
   const baseUrl = serverEnv.FE_SMCR_CRM_API_URL?.replace(/\/$/, "");
   if (!baseUrl) {
     logger.warn(

--- a/apps/sm-fe-smcr/lib/actions/delegation.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/delegation.action.ts
@@ -6,6 +6,7 @@ import {
   deleteDelegation,
 } from "../services/delegations.service";
 import { validateFormData } from "../utils";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const addDelegationSchema = z
   .object({
@@ -63,7 +64,7 @@ export async function addDelegationAction(
   const { error } = await addDelegation(input);
 
   if (error) {
-    console.error("Errore durante il salvataggio della delega:", error);
+    logServerError(error, "Errore durante il salvataggio della delega");
 
     return {
       fields: input,
@@ -97,7 +98,7 @@ export async function deleteDelegationAction(
 
   const { error } = await deleteDelegation(input);
   if (error) {
-    console.error("Errore durante l'eliminazione della delega:", error);
+    logServerError(error, "Errore durante l'eliminazione della delega");
 
     return {
       fields: input,

--- a/apps/sm-fe-smcr/lib/actions/members.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/members.action.ts
@@ -8,6 +8,7 @@ import { deleteMemberById as deleteMemberByIdService } from "@/lib/services/memb
 import { validateFormData } from "@/lib/utils";
 import { revalidatePath } from "next/cache";
 import z from "zod";
+import { logServerInfo } from "@/lib/logger/logger.server.helpers";
 
 const updateMemberTeamSchema = z.object({
   memberId: z.coerce.number().int(),
@@ -49,7 +50,7 @@ export async function updateMemberTeamAction(
     return { data: input, error: errors };
   }
 
-  console.log(input);
+  logServerInfo("updateMemberTeamAction input", input);
   let result: { error: unknown };
 
   if (input.active) {

--- a/apps/sm-fe-smcr/lib/actions/product.actions.ts
+++ b/apps/sm-fe-smcr/lib/actions/product.actions.ts
@@ -2,6 +2,7 @@
 
 import z from "zod";
 import { sendQueueMessage } from "../services/product.service";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const sendToQueueSchema = z.object({
   onboarding: z.string(),
@@ -37,7 +38,7 @@ export async function sendToQueueAction(
   const { error } = await sendQueueMessage(validation.data.onboarding);
 
   if (error) {
-    console.error(error);
+    logServerError(error, "sendToQueueAction - send queue message error");
     return {
       fields: validation.data,
       errors: { root: "Si è verificato un errore, riprova più tardi." },

--- a/apps/sm-fe-smcr/lib/actions/report.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/report.action.ts
@@ -2,6 +2,7 @@
 
 import z from "zod";
 import { serverEnv } from "@/config/env";
+import logger from "@/lib/logger/logger.server";
 
 const reportErrorSchema = z.object({
   title: z
@@ -45,7 +46,10 @@ export async function reportError(
 
   const webhook = serverEnv.FE_SMCR_API_SLACK_REPORT_HOOK;
   if (!webhook) {
-    console.error(
+    logger.error(
+      {
+        info: { event: "report-error.missing-slack-webhook" },
+      },
       "Errore durante l'invio della segnalazione, env FE_SMCR_API_SLACK_REPORT_HOOK mancante.",
     );
     return {
@@ -81,9 +85,14 @@ export async function reportError(
   });
 
   if (!response.ok) {
-    console.error(
-      "Errore durante l'invio della segnalazione, status:",
-      response.status,
+    logger.error(
+      {
+        info: {
+          event: "report-error.slack-webhook-failed",
+          metadata: { status: response.status },
+        },
+      },
+      "Errore durante l'invio della segnalazione",
     );
 
     return {

--- a/apps/sm-fe-smcr/lib/actions/team.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/team.action.ts
@@ -1,5 +1,6 @@
 // import { Team } from "../types/team";
 import { clientEnv } from "@/config/env";
+import clientLogger from "@/lib/logger/logger.client";
 
 const baseUrl = clientEnv.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -15,10 +16,9 @@ export const getTeams = async () =>
       });
 
       const data = await response.json();
-      // console.log("Teams exist in database:", data);
       return data; //setTeams(data);
     } catch (error) {
-      console.error("Error retrieving teams in database:", error);
+      void clientLogger.error({ error }, "Error retrieving teams in database");
     }
   };
 
@@ -35,7 +35,7 @@ export const getTeamById = async (teamId: string) => {
     const data = await response.json();
     return data;
   } catch (error) {
-    console.error("Error retrieving team in database:", error);
+    void clientLogger.error({ error }, "Error retrieving team in database");
   }
 };
 
@@ -51,7 +51,10 @@ export const getTeamMembers = async (teamId: string) => {
     const data = await response.json();
     return data; //setTeams(data);
   } catch (error) {
-    console.error("Error retrieving member in team in database:", error);
+    void clientLogger.error(
+      { error },
+      "Error retrieving member in team in database",
+    );
   }
 };
 
@@ -66,10 +69,18 @@ export async function removeUserFromTeam(memberId: string, teamId: string) {
     });
 
     const res1 = await res.json();
-    console.log(res1);
+    void clientLogger.info(
+      {
+        info: {
+          event: "team.member.removed",
+          metadata: { memberId, teamId, result: res1 },
+        },
+      },
+      "User removed from team",
+    );
     return res1;
   } catch (err) {
-    console.error("Errore nella fetch removeUserFromTeam", err);
+    void clientLogger.error({ error: err }, "Errore nella fetch removeUserFromTeam");
     return { error: "Errore di rete" };
   }
 }
@@ -84,7 +95,7 @@ export async function deleteTeam(teamId: string) {
 
     return await res.json();
   } catch (err) {
-    console.error("Errore nella fetch removeTeam", err);
+    void clientLogger.error({ error: err }, "Errore nella fetch removeTeam");
     return { error: "Errore di rete" };
   }
 }
@@ -104,7 +115,10 @@ export async function updateUserRoleInTeam(
 
     return await res.json();
   } catch (err) {
-    console.error("Errore nella fetch updateUserRoleInTeam", err);
+    void clientLogger.error(
+      { error: err },
+      "Errore nella fetch updateUserRoleInTeam",
+    );
     return { error: "Errore di rete" };
   }
 }
@@ -122,9 +136,7 @@ export async function updateUserRoleInTeam(
 //     });
 
 //     const data = await response.json();
-//     console.log("Teams add:", data);
 //   } catch (error) {
-//     console.error("Error add team to user:", error);
 //   }
 // }
 export async function addUserToTeam(
@@ -142,6 +154,6 @@ export async function addUserToTeam(
     const data = await res.json();
     return data;
   } catch (err) {
-    console.error("Errore aggiunta utente:", err);
+    void clientLogger.error({ error: err }, "Errore aggiunta utente");
   }
 }

--- a/apps/sm-fe-smcr/lib/actions/teams.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/teams.action.ts
@@ -12,6 +12,7 @@ import {
 import { validateFormData } from "@/lib/utils";
 import { revalidatePath } from "next/cache";
 import z from "zod";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const createTeamSchema = teamSchema.pick({
   name: true,
@@ -36,7 +37,7 @@ export async function createTeamAction(
 
   const result = await createTeam({ ...input, icon: "" });
   if (result.error) {
-    console.error(result.error);
+    logServerError(result.error, "createTeamAction - create team error");
     return {
       data: input,
       error: {

--- a/apps/sm-fe-smcr/lib/actions/user.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/user.action.ts
@@ -3,6 +3,7 @@ import { Team } from "../types/team";
 import { User } from "../types/user";
 import { Preferences } from "../types/userProfile";
 import { clientEnv } from "@/config/env";
+import clientLogger from "@/lib/logger/logger.client";
 
 const baseUrl = clientEnv.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -18,7 +19,10 @@ export const getUser = async () =>
       });
 
       const data = await response.json();
-      console.log("Users retrieved:", data);
+      void clientLogger.info(
+        { info: { event: "user.list.retrieved", metadata: { count: data.length } } },
+        "Users retrieved",
+      );
 
       // Aggiungi la proprietà `teams` vuota per ogni utente
       const user = data.map((user: User) => ({
@@ -30,7 +34,7 @@ export const getUser = async () =>
       //setUsers(usersWithTeams);
       return user;
     } catch (error) {
-      console.error("Error retrieving users:", error);
+      void clientLogger.error({ error }, "Error retrieving users");
     }
   };
 
@@ -48,12 +52,15 @@ export const getUserTeams = async (
       },
     });
 
-    const data = await response.json();
-    console.log("Teams for user retrieved from database:", data);
+      const data = await response.json();
+      void clientLogger.info(
+        { info: { event: "user.teams.retrieved", metadata: { userId } } },
+        "Teams for user retrieved from database",
+      );
     if (data) return data.teams; // Restituisci i team per l'utente
     return [];
   } catch (error) {
-    console.error("Error retrieving teams for user:", error);
+    void clientLogger.error({ error }, "Error retrieving teams for user");
     return []; // Se c'è un errore, restituisci un array vuoto
   }
 };
@@ -67,12 +74,15 @@ export const getUserMember = async (userId: string): Promise<Member[]> => {
       },
     });
 
-    const data = await response.json();
-    console.log("Members for user retrieved from database:", data);
+      const data = await response.json();
+      void clientLogger.info(
+        { info: { event: "user.members.retrieved", metadata: { userId } } },
+        "Members for user retrieved from database",
+      );
     if (data) return data; // Restituisci i team per l'utente
     return [];
   } catch (error) {
-    console.error("Error retrieving members for user:", error);
+    void clientLogger.error({ error }, "Error retrieving members for user");
     return []; // Se c'è un errore, restituisci un array vuoto
   }
 };
@@ -89,11 +99,10 @@ export const getUsers = async () =>
       });
 
       const data = await response.json();
-      // console.log("List of users retrieved from database:", data);
       // setUserList(data);
       return data;
     } catch (error) {
-      console.error("Error retrieving list of user:", error);
+      void clientLogger.error({ error }, "Error retrieving list of user");
       return []; // Se c'è un errore, restituisci un array vuoto
     }
   };
@@ -112,13 +121,16 @@ export const getUserPreferences = async (
       },
     });
 
-    const data = await response.json();
-    console.log("Preferences for user retrieved from database:", data);
+      const data = await response.json();
+      void clientLogger.info(
+        { info: { event: "user.preferences.retrieved", metadata: { userId } } },
+        "Preferences for user retrieved from database",
+      );
     return data;
   } catch (error) {
-    console.error(
-      "Error retrieving preferences for user, apply default:",
-      error,
+    void clientLogger.error(
+      { error },
+      "Error retrieving preferences for user, apply default",
     );
     return { teamId: null, theme: "light" };
   }
@@ -139,10 +151,18 @@ export const postUserPreferences = async (
     });
 
     const data = await response.json();
-    console.log("Preferences for user saved to database:", data);
+    void clientLogger.info(
+      {
+        info: {
+          event: "user.preferences.saved",
+          metadata: { userId, status: response.status, data },
+        },
+      },
+      "Preferences for user saved to database",
+    );
     return true;
   } catch (error) {
-    console.error("Error saving preferences for user:", error);
+    void clientLogger.error({ error }, "Error saving preferences for user");
     return false;
   }
 };

--- a/apps/sm-fe-smcr/lib/actions/users.actions.ts
+++ b/apps/sm-fe-smcr/lib/actions/users.actions.ts
@@ -8,6 +8,7 @@ import {
   updateUser,
 } from "../services/users.service";
 import { revalidateTag } from "next/cache";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const createUserSchema = z.object({
   isPNPG: z
@@ -92,7 +93,7 @@ export async function createUserAction(
       });
 
   if (error) {
-    console.log(error);
+    logServerError(error, "createUserAction - create user error");
     return {
       fields: { ...validation.data },
       errors: {

--- a/apps/sm-fe-smcr/lib/email.ts
+++ b/apps/sm-fe-smcr/lib/email.ts
@@ -1,5 +1,6 @@
 import nodemailer from "nodemailer";
 import { serverEnv } from "@/config/env";
+import { logServerInfo } from "@/lib/logger/logger.server.helpers";
 
 type SendEmailParams = {
   to: string;
@@ -25,5 +26,5 @@ export async function sendEmail({ to, subject, text }: SendEmailParams) {
     text,
   });
 
-  console.log(response);
+  logServerInfo("Email sent", { messageId: response.messageId, accepted: response.accepted });
 }

--- a/apps/sm-fe-smcr/lib/knex.ts
+++ b/apps/sm-fe-smcr/lib/knex.ts
@@ -20,14 +20,6 @@ const rawPassword = Buffer.from(
 // Connection string
 const connectionString = `postgresql://${encodedUser}:${rawPassword}@${serverEnv.DB_HOST}:${port}/${serverEnv.DB_NAME}${sslEnabled ? "?sslmode=require" : ""}`;
 
-// Solo in sviluppo, stampa dettagli (evita in prod per sicurezza)
-// if (process.env.NODE_ENV !== "production") {
-//   console.log("[🔌 DB CONNECTION INFO]");
-//   console.log(`→ Host: ${process.env.DB_HOST}`);
-//   console.log(`→ SSL: ${sslEnabled ? "ENABLED" : "DISABLED"}`);
-//   console.log("-------------------------------------------------");
-// }
-
 // Singleton pattern per evitare troppi pool
 const knexConfig: Knex.Config = {
   client: "pg",
@@ -43,7 +35,7 @@ const knexConfig: Knex.Config = {
     createRetryIntervalMillis: 1000,
     afterCreate: (conn: any, done: any) => {
       if (process.env.NODE_ENV !== "production") {
-        console.log("✅ Nuova connessione al DB stabilita");
+        process.stdout.write("Nuova connessione al DB stabilita\n");
       }
       done(null, conn);
     },

--- a/apps/sm-fe-smcr/lib/logger/logger.client.ts
+++ b/apps/sm-fe-smcr/lib/logger/logger.client.ts
@@ -1,0 +1,69 @@
+import { toLogError, toLogMetadata } from "@/lib/logger/logger.utils";
+
+type ClientLogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+type ClientLogContext = {
+  requestId?: string;
+  message?: string;
+  error?: unknown;
+  info?: {
+    event?: string;
+    actor?: string;
+    subject?: string;
+    metadata?: unknown;
+  };
+};
+
+async function sendClientLog(
+  level: ClientLogLevel,
+  input: string | ClientLogContext,
+  fallbackMessage?: string,
+) {
+  const context = typeof input === "string" ? {} : input;
+  const message = typeof input === "string" ? input : fallbackMessage || input.message;
+
+  if (!message) {
+    return;
+  }
+
+  const payload = {
+    timestamp: new Date().toISOString(),
+    level,
+    service: "SMCR",
+    message,
+    requestId: context.requestId || crypto.randomUUID(),
+    error: context.error ? toLogError(context.error) : undefined,
+    info: context.info
+      ? {
+          ...context.info,
+          metadata: context.info.metadata
+            ? toLogMetadata(context.info.metadata)
+            : undefined,
+        }
+      : undefined,
+  };
+
+  try {
+    await fetch("/api/monitoring/logs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch {
+    // Client logging must never affect UI behavior.
+  }
+}
+
+const clientLogger = {
+  debug: (input: string | ClientLogContext, message?: string) =>
+    sendClientLog("DEBUG", input, message),
+  info: (input: string | ClientLogContext, message?: string) =>
+    sendClientLog("INFO", input, message),
+  warn: (input: string | ClientLogContext, message?: string) =>
+    sendClientLog("WARN", input, message),
+  error: (input: string | ClientLogContext, message?: string) =>
+    sendClientLog("ERROR", input, message),
+};
+
+export default clientLogger;

--- a/apps/sm-fe-smcr/lib/logger/logger.server.helpers.ts
+++ b/apps/sm-fe-smcr/lib/logger/logger.server.helpers.ts
@@ -1,0 +1,28 @@
+import logger from "@/lib/logger/logger.server";
+import { toLogError, toLogMetadata } from "@/lib/logger/logger.utils";
+
+export function logServerError(
+  error: unknown,
+  message: string,
+  metadata?: unknown,
+) {
+  logger.error(
+    {
+      error: toLogError(error),
+      info: metadata ? { metadata: toLogMetadata(metadata) } : undefined,
+    },
+    message,
+  );
+}
+
+export function logServerInfo(message: string, metadata?: unknown) {
+  if (!metadata) {
+    logger.info(message);
+    return;
+  }
+
+  logger.info(
+    { info: { metadata: toLogMetadata(metadata) } },
+    message,
+  );
+}

--- a/apps/sm-fe-smcr/lib/logger/logger.server.ts
+++ b/apps/sm-fe-smcr/lib/logger/logger.server.ts
@@ -14,7 +14,7 @@ const remoteStream = {
         body: JSON.stringify(log),
       });
     } catch (error) {
-      console.error("error sending log:", error);
+      process.stderr.write(`error sending log: ${String(error)}\n`);
     }
   },
 };

--- a/apps/sm-fe-smcr/lib/logger/logger.utils.ts
+++ b/apps/sm-fe-smcr/lib/logger/logger.utils.ts
@@ -1,0 +1,40 @@
+type LogError = {
+  name?: string | null;
+  message?: string | null;
+  stack?: string | null;
+};
+
+export function toLogError(error: unknown): LogError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    name: "Error",
+    message: typeof error === "string" ? error : safeStringify(error),
+  };
+}
+
+export function toLogMetadata(value: unknown): Record<string, unknown> {
+  try {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+    }
+  } catch {
+    return { value: String(value) };
+  }
+
+  return { value };
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/apps/sm-fe-smcr/lib/msalConfig.ts
+++ b/apps/sm-fe-smcr/lib/msalConfig.ts
@@ -1,16 +1,11 @@
 import { LogLevel, PublicClientApplication } from "@azure/msal-browser";
 import { clientEnv } from "@/config/env";
+import clientLogger from "@/lib/logger/logger.client";
 
 const CLIENT_ID = clientEnv.NEXT_PUBLIC_MSAL_CLIENT_ID;
 const TENANT_ID = clientEnv.NEXT_PUBLIC_MSAL_TENANT_ID;
 const REDIRECT_URI = clientEnv.NEXT_PUBLIC_MSAL_REDIRECT_URI;
 // const BASE_PATH = clientEnv.NEXT_PUBLIC_APP_URL ?? "/";
-// console.log("🔍 MSAL Config Debug:");
-// console.log("- CLIENT_ID:", CLIENT_ID ? "✅ Set" : "❌ Missing");
-// console.log("- TENANT_ID:", TENANT_ID ? "✅ Set" : "❌ Missing");
-// console.log("- REDIRECT_URI:", REDIRECT_URI ? "✅ Set" : "❌ Missing");
-// console.log("- BASE_PATH:", BASE_PATH ? "✅ Set" : "❌ Missing");
-// console.log("- Full REDIRECT_URI:", REDIRECT_URI);
 export const msalConfig = {
   auth: {
     clientId: CLIENT_ID,
@@ -30,16 +25,16 @@ export const msalConfig = {
         }
         switch (level) {
           case LogLevel.Error:
-            console.error(message);
+            void clientLogger.error(message);
             return;
           case LogLevel.Info:
-            console.info(message);
+            void clientLogger.info(message);
             return;
           case LogLevel.Verbose:
-            console.debug(message);
+            void clientLogger.debug(message);
             return;
           case LogLevel.Warning:
-            console.warn(message);
+            void clientLogger.warn(message);
             return;
           default:
             return;
@@ -62,8 +57,15 @@ export function getMsalInstance(): PublicClientApplication {
 export async function ensureInitialized() {
   const instance = getMsalInstance();
   if (!instance.getActiveAccount()) {
-    console.log("🧠 MSAL INSTANCE CREATED");
-    console.log("With config:", msalConfig);
+    void clientLogger.info(
+      {
+        info: {
+          event: "msal.instance.created",
+          metadata: { redirectUri: REDIRECT_URI },
+        },
+      },
+      "MSAL instance created",
+    );
     await instance.initialize();
   }
 

--- a/apps/sm-fe-smcr/lib/services/ask-me-anything.service.ts
+++ b/apps/sm-fe-smcr/lib/services/ask-me-anything.service.ts
@@ -1,6 +1,10 @@
 import database from "@/lib/knex";
 import { ServiceResult } from "@/lib/types";
 import z from "zod";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 const tableName = "ama_access";
 
@@ -38,7 +42,7 @@ export async function readAskMeAnythingMember(
   const parsed = askMeAnythingMemberSchema.safeParse(rawMember);
 
   if (!parsed.success) {
-    console.error("readAskMeAnythingMember - member not found", parsed.error);
+    logServerError(parsed.error, "readAskMeAnythingMember - member not found");
     return { data: null, error: "member not found" };
   }
 
@@ -66,16 +70,16 @@ export async function readAskMeAnythingMembers(): Promise<
     const parsed = z.array(askMeAnythingMemberSchema).safeParse(rawAccess);
 
     if (!parsed.success) {
-      console.error(
-        "readAskMeAnythingMembers - validation error",
+      logServerError(
         parsed.error,
+        "readAskMeAnythingMembers - validation error",
       );
       return { data: null, error: "validation error" };
     }
 
     return { data: parsed.data, error: null };
   } catch (error) {
-    console.error("readAskMeAnythingMembers - database error", error);
+    logServerError(error, "readAskMeAnythingMembers - database error");
     return { data: null, error: "database error" };
   }
 }
@@ -103,7 +107,9 @@ export async function createAskMeAnythingMember(input: {
       .first();
 
     if (alreadyExists) {
-      console.error(alreadyExists);
+      logServerInfo("createAskMeAnythingMember - member already exists", {
+        email: input.email,
+      });
       return {
         data: null,
         error: {
@@ -125,9 +131,9 @@ export async function createAskMeAnythingMember(input: {
 
     const parsed = askMeAnythingMemberSchema.safeParse(rawMember);
     if (!parsed.success) {
-      console.error(
-        "createAskMeAnythingMember - validation error",
+      logServerError(
         parsed.error,
+        "createAskMeAnythingMember - validation error",
       );
 
       return {
@@ -143,7 +149,7 @@ export async function createAskMeAnythingMember(input: {
 
     return { data: parsed.data, error: null };
   } catch (error) {
-    console.error("createAskMeAnythingMember - database error", error);
+    logServerError(error, "createAskMeAnythingMember - database error");
     return { data: null, error: { message: "database error" } };
   }
 }
@@ -181,9 +187,9 @@ export async function updateAskMeAnythingMember(input: {
 
     const parsed = askMeAnythingMemberSchema.safeParse(rawMember);
     if (!parsed.success) {
-      console.error(
-        "updateAskMeAnythingMember - validation error",
+      logServerError(
         parsed.error,
+        "updateAskMeAnythingMember - validation error",
       );
       return {
         data: null,
@@ -198,7 +204,7 @@ export async function updateAskMeAnythingMember(input: {
 
     return { data: parsed.data, error: null };
   } catch (error) {
-    console.error("updateAskMeAnythingMember - database error", error);
+    logServerError(error, "updateAskMeAnythingMember - database error");
     return { data: null, error: { message: "database error" } };
   }
 }
@@ -223,7 +229,7 @@ export async function deleteAskMeAnythingMember(input: {
 
     return { data: { id: input.id }, error: null };
   } catch (error) {
-    console.error("deleteAskMeAnythingMember - database error", error);
+    logServerError(error, "deleteAskMeAnythingMember - database error");
     return { data: null, error: { message: "database error" } };
   }
 }

--- a/apps/sm-fe-smcr/lib/services/delegations.service.ts
+++ b/apps/sm-fe-smcr/lib/services/delegations.service.ts
@@ -6,6 +6,7 @@ import {
   AddDelegationInput,
   DeleteDelegationInput,
 } from "../actions/delegation.action";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const delegationSchema = z
   .object({
@@ -64,7 +65,7 @@ export async function addDelegation(input: AddDelegationInput) {
       return { data: null, error: "Delegaa già presente." };
     }
 
-    console.error({ error });
+    logServerError(error, "addDelegation - fetch error");
     return { data: null, error: "Error adding delegation" };
   }
 
@@ -84,7 +85,7 @@ export async function deleteDelegation(input: DeleteDelegationInput) {
   );
 
   if (error) {
-    console.error({ error });
+    logServerError(error, "deleteDelegation - fetch error");
     return { data: null, error: "Error adding delegation" };
   }
 

--- a/apps/sm-fe-smcr/lib/services/firma-con-io.service.ts
+++ b/apps/sm-fe-smcr/lib/services/firma-con-io.service.ts
@@ -3,6 +3,7 @@
 import { betterFetch } from "@better-fetch/fetch";
 import { z } from "zod";
 import { type FirmaConIO, FirmaConIOSchema } from "./firma-con-io.schema";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 type GetFirmaConIOResponse =
   | {
@@ -38,7 +39,7 @@ export async function getFirmaConIoInstitution(
   );
 
   if (error || !data) {
-    console.error(error);
+    logServerError(error, "getFirmaConIoInstitution - fetch error");
     return { data: undefined, error: "Errore nel recupero dati" };
   }
 
@@ -71,7 +72,7 @@ export async function getFirmaConIoSignerID(formData: FormData) {
   );
 
   if (error || !data) {
-    console.error(error);
+    logServerError(error, "getFirmaConIoSignerID - fetch error");
     return { error: error.status, data: null };
   }
 

--- a/apps/sm-fe-smcr/lib/services/institution.service.ts
+++ b/apps/sm-fe-smcr/lib/services/institution.service.ts
@@ -4,6 +4,7 @@ import { betterFetch } from "@better-fetch/fetch";
 import { z } from "zod";
 import logger from "@/lib/logger/logger.server";
 import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const OnboardingSchema = z.object({
   productId: z.string(),
@@ -189,7 +190,7 @@ export async function getInstitutionPNPG(
   );
 
   if (error || !data) {
-    console.error(error);
+    logServerError(error, "getInstitutionPNPG - fetch error");
     return { data: [], error: "Errore nel recupero dati" };
   }
 
@@ -276,7 +277,7 @@ export async function updateInstitutionInfo(input: UpdateInsitutionInfoInput) {
   );
 
   if (error || !data) {
-    console.error(error);
+    logServerError(error, "updateInstitutionInfo - fetch error");
     return { error: "Si è verificato un errore, riprova più tardi." };
   }
 
@@ -315,7 +316,7 @@ export async function updateInstitutionInfoPNPG(
   );
 
   if (error || !data) {
-    console.error(error);
+    logServerError(error, "updateInstitutionInfoPNPG - fetch error");
     return { error: "Si è verificato un errore, riprova più tardi." };
   }
 
@@ -403,7 +404,7 @@ export async function getUserGroups(input: { institution: string }) {
   );
 
   if (error || !data) {
-    console.error(error);
+    logServerError(error, "getUserGroups - fetch error");
     return { error: "Si è verificato un errore, riprova più tardi." };
   }
 

--- a/apps/sm-fe-smcr/lib/services/members.service.ts
+++ b/apps/sm-fe-smcr/lib/services/members.service.ts
@@ -3,6 +3,7 @@
 import database from "@/lib/knex";
 import z from "zod";
 import { readMemberTeams, teamSchema } from "./teams.service";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const memberSchema = z.object({
   id: z.number(),
@@ -25,7 +26,7 @@ export async function readMembers() {
   const rawMembers = await database.from("members").select("*");
   const members = z.array(memberSchema).safeParse(rawMembers);
   if (!members.success) {
-    console.error("readMembers - validation error", members.error);
+    logServerError(members.error, "readMembers - validation error");
     return { data: null, error: "validation error" };
   }
 
@@ -55,7 +56,7 @@ export async function readMemberByEmail(
 
   const member = memberSchema.safeParse(rawMember);
   if (!member.success) {
-    console.error("readMemberByEmail - validation error", member.error);
+    logServerError(member.error, "readMemberByEmail - validation error");
     return { data: null, error: "validation error" };
   }
 
@@ -84,13 +85,13 @@ export async function createMember(input: {
 
     const member = memberSchema.safeParse(rawMember);
     if (!member.success) {
-      console.error("createMember - validation error", member.error);
+      logServerError(member.error, "createMember - validation error");
       return { data: null, error: "validation error" };
     }
 
     return { data: member.data, error: null };
   } catch (error) {
-    console.error("createMember - database error", error);
+    logServerError(error, "createMember - database error");
     return { data: null, error: "database error" };
   }
 }
@@ -125,7 +126,7 @@ export async function deleteMemberById(input: {
 
     return { data: { id: deletedMemberId }, error: null };
   } catch (error) {
-    console.error("deleteMemberById - database error", error);
+    logServerError(error, "deleteMemberById - database error");
     return { data: null, error: "database error" };
   }
 }

--- a/apps/sm-fe-smcr/lib/services/portale-fatturazione.service.ts
+++ b/apps/sm-fe-smcr/lib/services/portale-fatturazione.service.ts
@@ -1,6 +1,7 @@
 "use server";
 import { betterFetch } from "@better-fetch/fetch";
 import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const STORAGE_TOKEN = serverEnv.STORAGE_TOKEN as string;
 const WEBHOOK_MANUAL_STORAGE = serverEnv.WEBHOOK_MANUAL_STORAGE as string;
@@ -26,7 +27,7 @@ export async function updateManual(file: File, fileName: string) {
     );
 
     if (error || !data) {
-      console.error(error);
+      logServerError(error, "updateManual - upload error");
       if (error?.status === 403)
         return {
           error: "Non autorizzato al caricamento del file, controllare la VPN",
@@ -43,7 +44,7 @@ export async function updateManual(file: File, fileName: string) {
 
     return { error: null, data: data as string };
   } catch (error) {
-    console.error(error);
+    logServerError(error, "updateManual - unexpected error");
     return { error: "Si è verificato un errore, riprova più tardi." };
   }
 }
@@ -99,7 +100,7 @@ export async function slackMessageManual() {
   });
 
   if (error || !data) {
-    console.error(error);
+    logServerError(error, "slackMessageManual - webhook error");
     return {
       error:
         "Si è verificato un errore nell'invio del messaggio su Slack, riprova più tardi.",

--- a/apps/sm-fe-smcr/lib/services/product.service.ts
+++ b/apps/sm-fe-smcr/lib/services/product.service.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import logger from "@/lib/logger/logger.server";
 import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 async function streamToBuffer(stream: Readable): Promise<Buffer> {
   const chunks: Buffer[] = [];
@@ -31,7 +32,7 @@ export async function verifyContract(product: string) {
   );
 
   if (error) {
-    console.error(error);
+    logServerError(error, "verifyContract - fetch error");
     return false;
   }
 
@@ -62,7 +63,7 @@ export async function getOnboardingByProduct(
   );
 
   if (result.error) {
-    console.error(result.error);
+    logServerError(result.error, "getOnboardingByProduct - fetch error");
     return {
       data: null,
       error: "Si è verificato un errore, riprova più tardi.",
@@ -280,7 +281,7 @@ export async function sendQueueMessage(onboarding: string) {
   );
 
   if (error) {
-    console.error(error);
+    logServerError(error, "sendQueueMessage - fetch error");
     return {
       data: null,
       error: "Si è verificato un errore, riprova più tardi.",

--- a/apps/sm-fe-smcr/lib/services/services-messages.service.ts
+++ b/apps/sm-fe-smcr/lib/services/services-messages.service.ts
@@ -3,6 +3,7 @@
 import { betterFetch } from "@better-fetch/fetch";
 import z from "zod";
 import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const LIMIT = 20;
 
@@ -89,7 +90,7 @@ export async function getServices(query: string) {
   );
 
   if (error) {
-    console.error(error);
+    logServerError(error, "getServices - fetch error");
     return { data: null, error };
   }
 
@@ -153,7 +154,7 @@ export async function getMessagesCount(
   );
 
   if (error) {
-    console.error(error);
+    logServerError(error, "getMessagesCount - fetch error");
     return { data: null, error: "Error" };
   }
 

--- a/apps/sm-fe-smcr/lib/services/teams.service.ts
+++ b/apps/sm-fe-smcr/lib/services/teams.service.ts
@@ -1,5 +1,9 @@
 import database from "@/lib/knex";
 import z from "zod";
+import {
+  logServerError,
+  logServerInfo,
+} from "@/lib/logger/logger.server.helpers";
 
 export const teamSchema = z.object({
   id: z.number(),
@@ -96,23 +100,20 @@ export async function submitTeamAccessRequest(
       fields.reason = flatErrors.reason[0];
     }
 
-    console.error(
-      "submitTeamAccessRequest - validation error",
-      validation.error,
-    );
+    logServerError(validation.error, "submitTeamAccessRequest - validation error");
 
     return { data: null, error: "validation error", fields };
   }
 
   try {
-    console.info("submitTeamAccessRequest - payload", {
+    logServerInfo("submitTeamAccessRequest - payload", {
       team: validation.data.team,
       reason: validation.data.reason,
     });
 
     return { data: validation.data, error: null, fields: null };
   } catch (error) {
-    console.error("submitTeamAccessRequest - internal error", error);
+    logServerError(error, "submitTeamAccessRequest - internal error");
     return { data: null, error: "internal error", fields: null };
   }
 }
@@ -142,7 +143,7 @@ export async function readTeams() {
   const rawTeams = await database.from("teams").select("*");
   const teams = z.array(teamSchema).safeParse(rawTeams);
   if (!teams.success) {
-    console.error("readTeams - validation error", teams.error);
+    logServerError(teams.error, "readTeams - validation error");
     return { data: null, error: "validation error" };
   }
 
@@ -153,9 +154,9 @@ export async function readTeams() {
     .array(teamPermissionSchema)
     .safeParse(rawTeamPermissions);
   if (!teamPermissions.success) {
-    console.error(
-      "readPermissions - team permissions validation error",
+    logServerError(
       teamPermissions.error,
+      "readPermissions - team permissions validation error",
     );
     return { data: null, error: "validation error" };
   }
@@ -182,9 +183,9 @@ export async function readTeamMemberCounts() {
 
     const parsedCounts = z.array(teamMembersCountSchema).safeParse(rawCounts);
     if (!parsedCounts.success) {
-      console.error(
-        "readTeamMemberCounts - validation error",
+      logServerError(
         parsedCounts.error,
+        "readTeamMemberCounts - validation error",
       );
       return { data: null, error: "validation error" };
     }
@@ -198,7 +199,7 @@ export async function readTeamMemberCounts() {
 
     return { data: memberCountsByTeamId, error: null };
   } catch (error) {
-    console.error("readTeamMemberCounts - database error", error);
+    logServerError(error, "readTeamMemberCounts - database error");
     return { data: null, error: "database error" };
   }
 }
@@ -217,13 +218,13 @@ export async function readTeamById(teamId: number) {
 
     const team = teamSchema.safeParse(rawTeam);
     if (!team.success) {
-      console.error("readTeamById - validation error", team.error);
+      logServerError(team.error, "readTeamById - validation error");
       return { data: null, error: "validation error" };
     }
 
     return { data: team.data, error: null };
   } catch (error) {
-    console.error("readTeamById - database error", error);
+    logServerError(error, "readTeamById - database error");
     return { data: null, error: "database error" };
   }
 }
@@ -252,7 +253,7 @@ export async function deleteTeamById(input: {
       .safeParse(rawTeam);
 
     if (!parsedTeam.success) {
-      console.error("deleteTeamById - validation error", parsedTeam.error);
+      logServerError(parsedTeam.error, "deleteTeamById - validation error");
       return {
         data: null,
         error: { code: "validation_error", message: "validation error" },
@@ -283,7 +284,7 @@ export async function deleteTeamById(input: {
 
     return { data: { id: input.teamId }, error: null };
   } catch (error) {
-    console.error("deleteTeamById - database error", error);
+    logServerError(error, "deleteTeamById - database error");
     return {
       data: null,
       error: { code: "database_error", message: "database error" },
@@ -321,7 +322,7 @@ export async function updateTeamById(input: {
 
     const team = teamSchema.safeParse(rawTeam);
     if (!team.success) {
-      console.error("updateTeamById - validation error", team.error);
+      logServerError(team.error, "updateTeamById - validation error");
       return {
         data: null,
         error: {
@@ -333,7 +334,7 @@ export async function updateTeamById(input: {
 
     return { data: team.data, error: null };
   } catch (error: unknown) {
-    console.error("updateTeamById - database error", error);
+    logServerError(error, "updateTeamById - database error");
 
     if (
       typeof error === "object" &&
@@ -393,7 +394,7 @@ export async function createTeam(input: {
 
   const validation = z.array(teamSchema).safeParse(result);
   if (!validation.success) {
-    console.error("createTeam - validation error", validation.error);
+    logServerError(validation.error, "createTeam - validation error");
     return { data: null, error: "validation error" };
   }
 
@@ -404,9 +405,9 @@ export async function readPermissions() {
   const rawFeatures = await database.from("features").select("*");
   const features = z.array(featureSchema).safeParse(rawFeatures);
   if (!features.success) {
-    console.error(
-      "readPermissions - features validation error",
+    logServerError(
       features.error,
+      "readPermissions - features validation error",
     );
     return { data: null, error: "validation error" };
   }
@@ -414,9 +415,9 @@ export async function readPermissions() {
   const rawPermissions = await database.from("permissions").select("*");
   const permissions = z.array(permissionSchema).safeParse(rawPermissions);
   if (!permissions.success) {
-    console.error(
-      "readPermissions - permissions validation error",
+    logServerError(
       permissions.error,
+      "readPermissions - permissions validation error",
     );
     return { data: null, error: "validation error" };
   }
@@ -525,7 +526,7 @@ export async function syncTeamPermissions(input: {
       error: null,
     };
   } catch (error) {
-    console.error("syncTeamPermissions - database error", error);
+    logServerError(error, "syncTeamPermissions - database error");
     return {
       data: null,
       error: {
@@ -544,7 +545,7 @@ export async function readMemberTeams(memberId: number) {
     .where({ memberId: memberId });
   const teams = z.array(teamSchema).safeParse(rawTeams);
   if (!teams.success) {
-    console.error("readTeams - validation error", teams.error);
+    logServerError(teams.error, "readTeams - validation error");
     return { data: null, error: "validation error" };
   }
 
@@ -566,7 +567,7 @@ export async function createMemberTeam(input: {
 
     return { error: null };
   } catch (error) {
-    console.error(error);
+    logServerError(error, "createMemberTeam - database error");
     return { error };
   }
 }
@@ -583,7 +584,7 @@ export async function removeMemberTeam(input: {
 
     return { error: null };
   } catch (error) {
-    console.error(error);
+    logServerError(error, "removeMemberTeam - database error");
     return { error };
   }
 }

--- a/apps/sm-fe-smcr/lib/services/users.service.ts
+++ b/apps/sm-fe-smcr/lib/services/users.service.ts
@@ -3,6 +3,7 @@
 import { betterFetch } from "@better-fetch/fetch";
 import { z } from "zod";
 import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
 
 const UserSchema = z.object({
   id: z.string().uuid(),
@@ -50,7 +51,7 @@ export async function getUsersByInstitutionId(
   );
 
   if (error) {
-    console.error(error);
+    logServerError(error, "getUsersByInstitutionId - fetch error");
     return [];
   }
 
@@ -73,7 +74,7 @@ export async function getUsersPNPGByInstitutionId(institutionId: string) {
   );
 
   if (error) {
-    console.error(error);
+    logServerError(error, "getUsersPNPGByInstitutionId - fetch error");
     return [];
   }
 
@@ -161,7 +162,9 @@ export async function createUserPNPG(input: {
       }),
     },
   );
-  console.log({ error });
+  if (error) {
+    logServerError(error, "createUserPNPG - fetch error");
+  }
 
   return { data, error };
 }

--- a/apps/sm-fe-smcr/scripts/package.js
+++ b/apps/sm-fe-smcr/scripts/package.js
@@ -14,7 +14,7 @@ async function createPackage() {
   });
 
   output.on("close", () => {
-    console.log("Package created successfully");
+    process.stdout.write("Package created successfully\n");
   });
 
   archive.on("error", (err) => {


### PR DESCRIPTION
- Add a client logger that sends browser diagnostics to `/api/monitoring/logs`.
- Replace server-side `console.*` usage with structured `logger.server` calls.
- Remove leftover debug console statements and keep non-app fallbacks on stdout/stderr.
