### PR TITLE
fix: use z.coerce.number() for tipologia referente map values

### DIFF
--- a/apps/sm-crm-fn/_shared/utils/config.ts
+++ b/apps/sm-crm-fn/_shared/utils/config.ts
@@ -101,7 +101,7 @@ const configSchema = z.object({
       } catch {
         throw new Error("CRM_TIPOLOGIA_REFERENTE_MAP_UAT: JSON non valido");
       }
-    }, z.record(z.string(), z.number())),
+    }, z.record(z.string(), z.coerce.number())),
   /**
    * Mappa tipologie referente CRM per ambiente PROD (JSON serializzato da Key Vault).
    * Formato: Record<TipologiaReferente, number>.
@@ -116,7 +116,7 @@ const configSchema = z.object({
       } catch {
         throw new Error("CRM_TIPOLOGIA_REFERENTE_MAP_PROD: JSON non valido");
       }
-    }, z.record(z.string(), z.number())),
+    }, z.record(z.string(), z.coerce.number())),
 });
 
 export type AppConfig = z.infer<typeof configSchema>;


### PR DESCRIPTION
In Zod v4, z.record(z.string(), z.number()) fails with "v.replace is not a function" when map values arrive as numeric strings instead of numbers. z.coerce.number() handles both cases.