### PR TITLE
feat(infra): add signature function app (prod only)

### DIFF
--- a/infra/resources/environments/prod.yaml
+++ b/infra/resources/environments/prod.yaml
@@ -191,3 +191,9 @@ certificates:
   __local: yaml_certificates_func
   API_KEY: "kv:fe_cert_api_key"
   SMTP_PASSWORD: "kv:askmebot_smtp_password"
+
+# ─── Signature Validation Function ───────────────────────────────────────────
+signature:
+  __local: yaml_signature_func
+  DSS_API_BASE_URL: "http://dss-api-dem.northeurope.azurecontainer.io:8080"
+  MAX_FILE_SIZE_BYTES: "10485760"

--- a/infra/resources/prod/locals.tf
+++ b/infra/resources/prod/locals.tf
@@ -79,6 +79,10 @@ locals {
   auth_func_app_settings      = local.yaml_auth_func_app_settings
   auth_slot_func_app_settings = local.yaml_auth_func_slot_app_settings
 
+  # 9. Signature Validation Function
+  signature_func_app_settings      = local.yaml_signature_func_app_settings
+  signature_slot_func_app_settings = local.yaml_signature_func_slot_app_settings
+
 
   # OLD HARDCODED CONFIGURATION (COMMENTED OUT FOR REFERENCE)
   # crm_func_app_settings = {

--- a/infra/resources/prod/locals_yaml.tf
+++ b/infra/resources/prod/locals_yaml.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-06-15 09:28
+# Generato il: 2026-06-16 11:24
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 
@@ -151,7 +151,7 @@ locals {
     JWT_AUDIENCE             = "plsm-fe-smcr"
     NODE_ENV                 = "production"
     WEBSITE_RUN_FROM_PACKAGE = "1"
-    MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net/api/auth/callback"
+    MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net/api/auth/callback/microsoft"
   }
 
   yaml_auth_func_slot_app_settings = {
@@ -163,7 +163,7 @@ locals {
     JWT_AUDIENCE             = "plsm-fe-smcr-staging"
     NODE_ENV                 = "production"
     WEBSITE_RUN_FROM_PACKAGE = "1"
-    MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net/api/auth/callback"
+    MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net/api/auth/callback/microsoft"
   }
 
   # ────────────────────────────────────────────────────────────
@@ -328,6 +328,17 @@ locals {
   }
 
   yaml_crm_func_slot_app_settings = local.yaml_crm_func_app_settings
+
+  # ────────────────────────────────────────────────────────────
+  # signature
+  # ────────────────────────────────────────────────────────────
+
+  yaml_signature_func_app_settings = {
+    DSS_API_BASE_URL    = "http://dss-api-dem.northeurope.azurecontainer.io:8080"
+    MAX_FILE_SIZE_BYTES = "10485760"
+  }
+
+  yaml_signature_func_slot_app_settings = local.yaml_signature_func_app_settings
 
   # ────────────────────────────────────────────────────────────────
   # Metadati ambiente

--- a/infra/resources/prod/network_cidrs.tf
+++ b/infra/resources/prod/network_cidrs.tf
@@ -66,3 +66,10 @@ resource "dx_available_subnet_cidr" "auth_fa_subnet_cidr" {
   prefix_length      = 24
   depends_on         = [module.crm_function]
 }
+
+# CIDR per la Function App: Signature
+resource "dx_available_subnet_cidr" "signature_fa_subnet_cidr" {
+  virtual_network_id = module.azure_core_infra.common_vnet.id
+  prefix_length      = 24
+  depends_on         = [module.auth_function]
+}

--- a/infra/resources/prod/signature.tf
+++ b/infra/resources/prod/signature.tf
@@ -1,0 +1,42 @@
+# =============================================================================
+# Signature Validation - Azure Function
+# =============================================================================
+
+module "signature_function" {
+  source = "../_modules/function_app"
+
+  environment = merge(local.environment, {
+    app_name        = "sig",
+    instance_number = "01"
+  })
+
+  application_insights_connection_string = data.azurerm_key_vault_secret.appinsights_connection_string.value
+  application_insights_key               = data.azurerm_key_vault_secret.appinsights_instrumentationkey.value
+
+  resource_group_name = azurerm_resource_group.fn_rg.name
+  tags                = local.tags
+
+  virtual_network = {
+    name                = module.azure_core_infra.common_vnet.name
+    resource_group_name = module.azure_core_infra.network_resource_group_name
+  }
+  subnet_pep_id = module.azure_core_infra.common_pep_snet.id
+  subnet_cidr   = dx_available_subnet_cidr.signature_fa_subnet_cidr.cidr_block
+
+  health_check_path = "/api/v1/health"
+  node_version      = 22
+  app_settings      = merge(local.common_app_settings, local.signature_func_app_settings)
+  slot_app_settings = merge(local.common_app_settings, local.signature_slot_func_app_settings)
+
+  depends_on = [module.azure_core_infra]
+}
+
+# -----------------------------------------------------------------------------
+# Role Assignments
+# -----------------------------------------------------------------------------
+
+resource "azurerm_role_assignment" "cd_identity_website_contributor_signature_func" {
+  scope                = module.signature_function.function_app_id
+  role_definition_name = "Website Contributor"
+  principal_id         = data.azurerm_user_assigned_identity.github_cd_identity.principal_id
+}

--- a/infra/resources/prod/tfmodules.lock.json
+++ b/infra/resources/prod/tfmodules.lock.json
@@ -58,5 +58,11 @@
     "version": "3.0.0",
     "name": "azure_function_app",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/3.0.0"
+  },
+  "signature_function.azurerm_linux_function_app": {
+    "hash": "a38c42efbd1577c3971123cc4f335a6827e0ead44695b9d014789e0598c2672d",
+    "version": "3.0.0",
+    "name": "azure_function_app",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/3.0.0"
   }
 }


### PR DESCRIPTION
## Descrizione
 
Con questa PR viene creata l’infrastruttura **SOLO** su **PROD-PLATFORM-SM** per la nuova Azure Function di validazione firma documenti prevista dalla task **SMION-756** (successiva a questa PR).
 
 La Function verrà usata da **SMCR** per inviare file `.pdf` o `.p7m` al servizio DSS e ottenere l’esito della verifica firme.
 
 ## Modifiche principali
 
 - Aggiunto blocco `signature` in `infra/resources/environments/prod.yaml`
 - Rigenerati i locals YAML prod per gli app settings:
   - `DSS_API_BASE_URL`
   - `MAX_FILE_SIZE_BYTES`
 - Aggiunta nuova Function App Terraform:
   - `plsm-p-itn-sig-func-01`
 - Aggiunto subnet CIDR dedicato:
   - `signature_fa_subnet_cidr`
 - Aggiunto role assignment `Website Contributor` per la managed identity GitHub CD
 
 ## Note
 
 - _Nessuna risorsa viene creata in DEV_.
 - La Function è configurata solo su subscription/resource group prod:
   - subscription: `PROD-PLATFORM-SM`
   - resource group: `plsm-p-itn-fn-rg-01`
 - La Function verrà deployata successivamente tramite workflow CD dedicato, dopo l’apply dell’infra.
 
 ## Terraform plan
 
 Plan verificato localmente su `PROD-PLATFORM-SM`:
 
 ```text
 Plan: 25 to add, 11 to change, 4 to destroy