### PR TITLE
[SMION-756] env smcr signature

### DIFF
--- a/docs/superpowers/plans/2026-06-22-yaml-sticky-app-settings.md
+++ b/docs/superpowers/plans/2026-06-22-yaml-sticky-app-settings.md
@@ -1,0 +1,161 @@
+# YAML Sticky App Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the infra YAML generator so applications can declare slot-sticky app settings with `__sticky`, and mark the FE-SMCR signature function settings as sticky.
+
+**Architecture:** `generate_locals.py` will read an optional `__sticky` list from each `__local` YAML section and emit a Terraform local named `<local>_sticky_app_setting_names`. The local app-service wrapper will expose `sticky_app_setting_names` and pass it to the upstream `pagopa-dx/azure-app-service` module. `app_fe_smcr.tf` will wire `local.yaml_fe_smcr_sticky_app_setting_names` into the FE App Service module.
+
+**Tech Stack:** Python YAML generator, Terraform AzureRM/DX modules, YAML env configuration.
+
+---
+
+### Task 1: Add sticky metadata generation
+
+**Files:**
+- Modify: `infra/scripts/generate_locals.py`
+
+- [ ] **Step 1: Add a failing generator expectation**
+
+Manually run the existing generator after adding `__sticky` to YAML (Task 3 will add it permanently):
+
+```yaml
+__sticky:
+  - SIGNATURE_FN_URL
+  - SIGNATURE_FN_KEY
+```
+
+Expected before implementation: no `yaml_fe_smcr_sticky_app_setting_names` appears in `infra/resources/prod/locals_yaml.tf`.
+
+- [ ] **Step 2: Update `generate_app_block`**
+
+Add support for:
+
+```python
+sticky = app_cfg.get("__sticky", []) or []
+```
+
+and emit after slot settings:
+
+```hcl
+yaml_fe_smcr_sticky_app_setting_names = [
+  "SIGNATURE_FN_URL",
+  "SIGNATURE_FN_KEY",
+]
+```
+
+If `__sticky` is missing or empty, emit:
+
+```hcl
+yaml_<name>_sticky_app_setting_names = []
+```
+
+- [ ] **Step 3: Regenerate prod locals**
+
+Run:
+
+```bash
+python3 infra/scripts/generate_locals.py --env prod
+```
+
+Expected: `infra/resources/prod/locals_yaml.tf` contains a `yaml_fe_smcr_sticky_app_setting_names` local.
+
+### Task 2: Expose sticky settings in the app-service wrapper
+
+**Files:**
+- Modify: `infra/resources/_modules/app_service/variables.tf`
+- Modify: `infra/resources/_modules/app_service/main.tf`
+
+- [ ] **Step 1: Add wrapper variable**
+
+Add:
+
+```hcl
+variable "sticky_app_setting_names" {
+  type        = list(string)
+  default     = []
+  description = "List of application setting names that are not swapped between slots."
+}
+```
+
+- [ ] **Step 2: Pass variable to DX module**
+
+In `module "azure_app_service"` add:
+
+```hcl
+sticky_app_setting_names = var.sticky_app_setting_names
+```
+
+### Task 3: Mark FE-SMCR signature settings as sticky
+
+**Files:**
+- Modify: `infra/resources/environments/prod.yaml`
+- Modify: `infra/resources/prod/app_fe_smcr.tf`
+
+- [ ] **Step 1: Add `__sticky` in YAML**
+
+Inside `fe_smcr`, add:
+
+```yaml
+  __sticky:
+    - SIGNATURE_FN_URL
+    - SIGNATURE_FN_KEY
+```
+
+Keep the existing shared settings:
+
+```yaml
+  SIGNATURE_FN_URL: "https://plsm-p-itn-sig-func-01.azurewebsites.net"
+  SIGNATURE_FN_KEY: "kv:fe_smcr_signature_fn_key"
+```
+
+- [ ] **Step 2: Wire FE module**
+
+In `infra/resources/prod/app_fe_smcr.tf`, add:
+
+```hcl
+sticky_app_setting_names = local.yaml_fe_smcr_sticky_app_setting_names
+```
+
+### Task 4: Validate and commit
+
+**Files:**
+- Generated: `infra/resources/prod/locals_yaml.tf`
+- Generated: `infra/resources/prod/data_kv.tf`
+
+- [ ] **Step 1: Format Terraform**
+
+Run:
+
+```bash
+terraform -chdir=infra/resources/prod fmt
+```
+
+- [ ] **Step 2: Run pre-commit / plan checks**
+
+Run:
+
+```bash
+pre-commit run --files infra/resources/prod/app_fe_smcr.tf infra/resources/prod/locals_yaml.tf infra/resources/prod/data_kv.tf infra/resources/environments/prod.yaml infra/resources/_modules/app_service/main.tf infra/resources/_modules/app_service/variables.tf
+```
+
+Expected: hooks pass or only modify generated files that are then committed.
+
+- [ ] **Step 3: Terraform plan**
+
+Run:
+
+```bash
+terraform -chdir=infra/resources/prod plan -input=false -lock=false -no-color
+```
+
+Expected: FE-SMCR app service `sticky_settings.app_setting_names` includes `SIGNATURE_FN_URL` and `SIGNATURE_FN_KEY`; app settings include the signature URL and Key Vault secret value reference.
+
+- [ ] **Step 4: Commit**
+
+Commit message:
+
+```bash
+git add infra/scripts/generate_locals.py infra/resources/_modules/app_service/main.tf infra/resources/_modules/app_service/variables.tf infra/resources/environments/prod.yaml infra/resources/prod/app_fe_smcr.tf infra/resources/prod/locals_yaml.tf infra/resources/prod/data_kv.tf docs/superpowers/plans/2026-06-22-yaml-sticky-app-settings.md
+git commit -m "feat(infra): support sticky app settings from YAML"
+```

--- a/infra/resources/_modules/app_service/main.tf
+++ b/infra/resources/_modules/app_service/main.tf
@@ -28,6 +28,8 @@ module "azure_app_service" {
   app_settings      = var.app_settings
   slot_app_settings = var.slot_app_settings
 
+  sticky_app_setting_names = var.sticky_app_setting_names
+
   health_check_path = var.health_check_path
   tags              = var.tags
 

--- a/infra/resources/_modules/app_service/variables.tf
+++ b/infra/resources/_modules/app_service/variables.tf
@@ -51,6 +51,12 @@ variable "slot_app_settings" {
   description = "Resources tags"
 }
 
+variable "sticky_app_setting_names" {
+  type        = list(string)
+  default     = []
+  description = "List of application setting names that are not swapped between slots."
+}
+
 variable "tags" {
   type        = map(any)
   description = "Resources tags"

--- a/infra/resources/environments/prod.yaml
+++ b/infra/resources/environments/prod.yaml
@@ -52,6 +52,11 @@ fe_smcr:
   __sticky:
     - SIGNATURE_FN_URL
     - SIGNATURE_FN_KEY
+    - AUTH_FUNCTION_BASE_URL
+    - AUTH_JWT_AUDIENCE
+    - AUTH_JWT_ISSUER
+    - NEXT_PUBLIC_APP_URL
+    - NEXT_PUBLIC_POST_LOGIN_REDIRECT
   # Segreti KV
   FE_SMCR_OCP_APIM_SUBSCRIPTION_KEY_UAT: "kv:fe_smcr_ocp_apim_subscription_key_uat"
   FE_SMCR_API_SLACK_CALL_MANAGEMENT_HOOK_TEST: "kv:fe_smcr_api_slack_call_management_hook_test"
@@ -105,8 +110,6 @@ fe_smcr:
   ONBOARDING_BASE_PATH: "https://api.selfcare.pagopa.it/"
   UPLOAD: "external/internal/v1/onboarding"
   TEST_ENDPOINT: "mytestendpoint"
-  SIGNATURE_FN_URL: "https://plsm-p-itn-sig-func-01.azurewebsites.net"
-  SIGNATURE_FN_KEY: "kv:fe_smcr_signature_fn_key"
   # Slot-specifici: URL pubblici
   production:
     NEXT_PUBLIC_APP_URL: "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net"
@@ -116,6 +119,8 @@ fe_smcr:
     AUTH_JWT_SECRET: "kv:auth_jwt_secret"
     AUTH_JWT_ISSUER: "plsm-auth-service"
     AUTH_JWT_AUDIENCE: "plsm-fe-smcr"
+    SIGNATURE_FN_URL: "https://plsm-p-itn-sig-func-01.azurewebsites.net"
+    SIGNATURE_FN_KEY: "kv:fe_smcr_signature_fn_key"
   staging:
     NEXT_PUBLIC_APP_URL: "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net"
     # NEXT_PUBLIC_MSAL_REDIRECT_URI: "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net/api/auth/callback/microsoft"
@@ -124,6 +129,8 @@ fe_smcr:
     AUTH_JWT_SECRET: "kv:auth_jwt_secret"
     AUTH_JWT_ISSUER: "plsm-auth-service-staging"
     AUTH_JWT_AUDIENCE: "plsm-fe-smcr-staging"
+    SIGNATURE_FN_URL: "https://plsm-p-itn-sig-func-01-staging.azurewebsites.net"
+    SIGNATURE_FN_KEY: "kv:fe_smcr_signature_fn_key"
 
 # ─── CRM Function (Dynamics CRM Integration) ─────────────────────────────────
 # Production = Staging (stessi valori per entrambi gli slot)

--- a/infra/resources/environments/prod.yaml
+++ b/infra/resources/environments/prod.yaml
@@ -191,3 +191,9 @@ certificates:
   __local: yaml_certificates_func
   API_KEY: "kv:fe_cert_api_key"
   SMTP_PASSWORD: "kv:askmebot_smtp_password"
+
+# ─── Signature Validation Function ───────────────────────────────────────────
+signature:
+  __local: yaml_signature_func
+  DSS_API_BASE_URL: "http://dss-api-dem.northeurope.azurecontainer.io:8080"
+  MAX_FILE_SIZE_BYTES: "10485760"

--- a/infra/resources/environments/prod.yaml
+++ b/infra/resources/environments/prod.yaml
@@ -49,6 +49,9 @@ backend_smcr:
 
 fe_smcr:
   __local: yaml_fe_smcr
+  __sticky:
+    - SIGNATURE_FN_URL
+    - SIGNATURE_FN_KEY
   # Segreti KV
   FE_SMCR_OCP_APIM_SUBSCRIPTION_KEY_UAT: "kv:fe_smcr_ocp_apim_subscription_key_uat"
   FE_SMCR_API_SLACK_CALL_MANAGEMENT_HOOK_TEST: "kv:fe_smcr_api_slack_call_management_hook_test"
@@ -102,6 +105,8 @@ fe_smcr:
   ONBOARDING_BASE_PATH: "https://api.selfcare.pagopa.it/"
   UPLOAD: "external/internal/v1/onboarding"
   TEST_ENDPOINT: "mytestendpoint"
+  SIGNATURE_FN_URL: "https://plsm-p-itn-sig-func-01.azurewebsites.net"
+  SIGNATURE_FN_KEY: "kv:fe_smcr_signature_fn_key"
   # Slot-specifici: URL pubblici
   production:
     NEXT_PUBLIC_APP_URL: "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net"

--- a/infra/resources/prod/app_fe_smcr.tf
+++ b/infra/resources/prod/app_fe_smcr.tf
@@ -20,6 +20,8 @@ module "azure_fe_app_service_smcr" {
   app_settings      = merge(local.common_app_settings, local.fe_smcr_app_settings)
   slot_app_settings = merge(local.common_app_settings, local.fe_smcr_slot_app_settings)
 
+  sticky_app_setting_names = local.yaml_fe_smcr_sticky_app_setting_names
+
   health_check_path = "/api/health"
   tags              = local.tags
 

--- a/infra/resources/prod/data_kv.tf
+++ b/infra/resources/prod/data_kv.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-06-22 12:12
+# Generato il: 2026-06-22 12:31
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 

--- a/infra/resources/prod/data_kv.tf
+++ b/infra/resources/prod/data_kv.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-06-15 09:28
+# Generato il: 2026-06-22 11:57
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 
@@ -101,5 +101,10 @@ data "azurerm_key_vault_secret" "fe_smcr_crm_api_url" {
 
 data "azurerm_key_vault_secret" "fe_smcr_logs_endpoint" {
   name         = "fe-smcr-logs-endpoint"
+  key_vault_id = module.azure_core_infra.common_key_vault.id
+}
+
+data "azurerm_key_vault_secret" "fe_smcr_signature_fn_key" {
+  name         = "fe-smcr-signature-fn-key"
   key_vault_id = module.azure_core_infra.common_key_vault.id
 }

--- a/infra/resources/prod/data_kv.tf
+++ b/infra/resources/prod/data_kv.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-06-22 11:57
+# Generato il: 2026-06-22 12:12
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 

--- a/infra/resources/prod/locals.tf
+++ b/infra/resources/prod/locals.tf
@@ -79,6 +79,10 @@ locals {
   auth_func_app_settings      = local.yaml_auth_func_app_settings
   auth_slot_func_app_settings = local.yaml_auth_func_slot_app_settings
 
+  # 9. Signature Validation Function
+  signature_func_app_settings      = local.yaml_signature_func_app_settings
+  signature_slot_func_app_settings = local.yaml_signature_func_slot_app_settings
+
 
   # OLD HARDCODED CONFIGURATION (COMMENTED OUT FOR REFERENCE)
   # crm_func_app_settings = {

--- a/infra/resources/prod/locals_yaml.tf
+++ b/infra/resources/prod/locals_yaml.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-06-15 09:28
+# Generato il: 2026-06-16 11:24
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 
@@ -151,7 +151,7 @@ locals {
     JWT_AUDIENCE             = "plsm-fe-smcr"
     NODE_ENV                 = "production"
     WEBSITE_RUN_FROM_PACKAGE = "1"
-    MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net/api/auth/callback"
+    MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net/api/auth/callback/microsoft"
   }
 
   yaml_auth_func_slot_app_settings = {
@@ -163,7 +163,7 @@ locals {
     JWT_AUDIENCE             = "plsm-fe-smcr-staging"
     NODE_ENV                 = "production"
     WEBSITE_RUN_FROM_PACKAGE = "1"
-    MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net/api/auth/callback"
+    MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net/api/auth/callback/microsoft"
   }
 
   # ────────────────────────────────────────────────────────────
@@ -328,6 +328,17 @@ locals {
   }
 
   yaml_crm_func_slot_app_settings = local.yaml_crm_func_app_settings
+
+  # ────────────────────────────────────────────────────────────
+  # signature
+  # ────────────────────────────────────────────────────────────
+
+  yaml_signature_func_app_settings = {
+    DSS_API_BASE_URL    = "http://dss-api-dem.northeurope.azurecontainer.io:8080"
+    MAX_FILE_SIZE_BYTES = "10485760"
+  }
+
+  yaml_signature_func_slot_app_settings = local.yaml_signature_func_app_settings
 
   # ────────────────────────────────────────────────────────────────
   # Metadati ambiente

--- a/infra/resources/prod/locals_yaml.tf
+++ b/infra/resources/prod/locals_yaml.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-06-16 11:24
+# Generato il: 2026-06-22 11:57
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 
@@ -21,6 +21,8 @@ locals {
   }
 
   yaml_common_slot_app_settings = local.yaml_common_app_settings
+
+  yaml_common_sticky_app_setting_names = []
 
   # ────────────────────────────────────────────────────────────
   # certificates
@@ -45,6 +47,8 @@ locals {
   }
 
   yaml_certificates_func_slot_app_settings = local.yaml_certificates_func_app_settings
+
+  yaml_certificates_func_sticky_app_setting_names = []
 
   # ────────────────────────────────────────────────────────────
   # onboarding
@@ -79,6 +83,8 @@ locals {
     APPINSIGHTS_INSTRUMENTATIONKEY        = data.azurerm_key_vault_secret.appinsights_instrumentationkey.value
     FE_SMCR_OCP_APIM_SUBSCRIPTION_KEY     = data.azurerm_key_vault_secret.FE_SMCR_OCP_APIM_SUBSCRIPTION_KEY.value
   }
+
+  yaml_onboarding_func_sticky_app_setting_names = []
 
   # ────────────────────────────────────────────────────────────
   # askmebot
@@ -138,6 +144,8 @@ locals {
     FE_SMCR_OCP_APIM_SUBSCRIPTION_KEY = data.azurerm_key_vault_secret.askmebot_ocp_apim_subscription_key.value
   }
 
+  yaml_askmebot_func_sticky_app_setting_names = []
+
   # ────────────────────────────────────────────────────────────
   # auth_func
   # ────────────────────────────────────────────────────────────
@@ -165,6 +173,8 @@ locals {
     WEBSITE_RUN_FROM_PACKAGE = "1"
     MSAL_REDIRECT_URI        = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net/api/auth/callback/microsoft"
   }
+
+  yaml_auth_func_sticky_app_setting_names = []
 
   # ────────────────────────────────────────────────────────────
   # fe_smcr
@@ -220,6 +230,8 @@ locals {
     ONBOARDING_BASE_PATH                                  = "https://api.selfcare.pagopa.it/"
     UPLOAD                                                = "external/internal/v1/onboarding"
     TEST_ENDPOINT                                         = "mytestendpoint"
+    SIGNATURE_FN_URL                                      = "https://plsm-p-itn-sig-func-01.azurewebsites.net"
+    SIGNATURE_FN_KEY                                      = data.azurerm_key_vault_secret.fe_smcr_signature_fn_key.value
     NEXT_PUBLIC_APP_URL                                   = "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net"
     NEXT_PUBLIC_POST_LOGIN_REDIRECT                       = "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net"
     AUTH_FUNCTION_BASE_URL                                = "https://plsm-p-itn-auth-func-01.azurewebsites.net"
@@ -278,6 +290,8 @@ locals {
     ONBOARDING_BASE_PATH                                  = "https://api.selfcare.pagopa.it/"
     UPLOAD                                                = "external/internal/v1/onboarding"
     TEST_ENDPOINT                                         = "mytestendpoint"
+    SIGNATURE_FN_URL                                      = "https://plsm-p-itn-sig-func-01.azurewebsites.net"
+    SIGNATURE_FN_KEY                                      = data.azurerm_key_vault_secret.fe_smcr_signature_fn_key.value
     NEXT_PUBLIC_APP_URL                                   = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net"
     NEXT_PUBLIC_POST_LOGIN_REDIRECT                       = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net"
     AUTH_FUNCTION_BASE_URL                                = "https://plsm-p-itn-auth-func-01-staging.azurewebsites.net"
@@ -285,6 +299,11 @@ locals {
     AUTH_JWT_ISSUER                                       = "plsm-auth-service-staging"
     AUTH_JWT_AUDIENCE                                     = "plsm-fe-smcr-staging"
   }
+
+  yaml_fe_smcr_sticky_app_setting_names = [
+    "SIGNATURE_FN_URL",
+    "SIGNATURE_FN_KEY",
+  ]
 
   # ────────────────────────────────────────────────────────────
   # portale_fatturazione
@@ -298,6 +317,8 @@ locals {
 
   yaml_pf_func_slot_app_settings = local.yaml_pf_func_app_settings
 
+  yaml_pf_func_sticky_app_setting_names = []
+
   # ────────────────────────────────────────────────────────────
   # backend_smcr
   # ────────────────────────────────────────────────────────────
@@ -305,6 +326,8 @@ locals {
   yaml_backend_app_settings = {}
 
   yaml_backend_slot_app_settings = local.yaml_backend_app_settings
+
+  yaml_backend_sticky_app_setting_names = []
 
   # ────────────────────────────────────────────────────────────
   # crm_function
@@ -329,6 +352,8 @@ locals {
 
   yaml_crm_func_slot_app_settings = local.yaml_crm_func_app_settings
 
+  yaml_crm_func_sticky_app_setting_names = []
+
   # ────────────────────────────────────────────────────────────
   # signature
   # ────────────────────────────────────────────────────────────
@@ -339,6 +364,8 @@ locals {
   }
 
   yaml_signature_func_slot_app_settings = local.yaml_signature_func_app_settings
+
+  yaml_signature_func_sticky_app_setting_names = []
 
   # ────────────────────────────────────────────────────────────────
   # Metadati ambiente

--- a/infra/resources/prod/locals_yaml.tf
+++ b/infra/resources/prod/locals_yaml.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-06-22 11:57
+# Generato il: 2026-06-22 12:12
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 

--- a/infra/resources/prod/locals_yaml.tf
+++ b/infra/resources/prod/locals_yaml.tf
@@ -1,6 +1,6 @@
 # =============================================================================
 # AUTO-GENERATED — NON modificare manualmente.
-# Generato il: 2026-06-22 12:12
+# Generato il: 2026-06-22 12:31
 # Per aggiornare: python3 infra/scripts/generate_locals.py --env prod
 # =============================================================================
 
@@ -230,14 +230,14 @@ locals {
     ONBOARDING_BASE_PATH                                  = "https://api.selfcare.pagopa.it/"
     UPLOAD                                                = "external/internal/v1/onboarding"
     TEST_ENDPOINT                                         = "mytestendpoint"
-    SIGNATURE_FN_URL                                      = "https://plsm-p-itn-sig-func-01.azurewebsites.net"
-    SIGNATURE_FN_KEY                                      = data.azurerm_key_vault_secret.fe_smcr_signature_fn_key.value
     NEXT_PUBLIC_APP_URL                                   = "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net"
     NEXT_PUBLIC_POST_LOGIN_REDIRECT                       = "https://plsm-p-itn-fe-smcr-app-01.azurewebsites.net"
     AUTH_FUNCTION_BASE_URL                                = "https://plsm-p-itn-auth-func-01.azurewebsites.net"
     AUTH_JWT_SECRET                                       = data.azurerm_key_vault_secret.auth_jwt_secret.value
     AUTH_JWT_ISSUER                                       = "plsm-auth-service"
     AUTH_JWT_AUDIENCE                                     = "plsm-fe-smcr"
+    SIGNATURE_FN_URL                                      = "https://plsm-p-itn-sig-func-01.azurewebsites.net"
+    SIGNATURE_FN_KEY                                      = data.azurerm_key_vault_secret.fe_smcr_signature_fn_key.value
   }
 
   yaml_fe_smcr_slot_app_settings = {
@@ -290,19 +290,24 @@ locals {
     ONBOARDING_BASE_PATH                                  = "https://api.selfcare.pagopa.it/"
     UPLOAD                                                = "external/internal/v1/onboarding"
     TEST_ENDPOINT                                         = "mytestendpoint"
-    SIGNATURE_FN_URL                                      = "https://plsm-p-itn-sig-func-01.azurewebsites.net"
-    SIGNATURE_FN_KEY                                      = data.azurerm_key_vault_secret.fe_smcr_signature_fn_key.value
     NEXT_PUBLIC_APP_URL                                   = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net"
     NEXT_PUBLIC_POST_LOGIN_REDIRECT                       = "https://plsm-p-itn-fe-smcr-app-01-staging.azurewebsites.net"
     AUTH_FUNCTION_BASE_URL                                = "https://plsm-p-itn-auth-func-01-staging.azurewebsites.net"
     AUTH_JWT_SECRET                                       = data.azurerm_key_vault_secret.auth_jwt_secret.value
     AUTH_JWT_ISSUER                                       = "plsm-auth-service-staging"
     AUTH_JWT_AUDIENCE                                     = "plsm-fe-smcr-staging"
+    SIGNATURE_FN_URL                                      = "https://plsm-p-itn-sig-func-01-staging.azurewebsites.net"
+    SIGNATURE_FN_KEY                                      = data.azurerm_key_vault_secret.fe_smcr_signature_fn_key.value
   }
 
   yaml_fe_smcr_sticky_app_setting_names = [
     "SIGNATURE_FN_URL",
     "SIGNATURE_FN_KEY",
+    "AUTH_FUNCTION_BASE_URL",
+    "AUTH_JWT_AUDIENCE",
+    "AUTH_JWT_ISSUER",
+    "NEXT_PUBLIC_APP_URL",
+    "NEXT_PUBLIC_POST_LOGIN_REDIRECT",
   ]
 
   # ────────────────────────────────────────────────────────────

--- a/infra/resources/prod/network_cidrs.tf
+++ b/infra/resources/prod/network_cidrs.tf
@@ -66,3 +66,10 @@ resource "dx_available_subnet_cidr" "auth_fa_subnet_cidr" {
   prefix_length      = 24
   depends_on         = [module.crm_function]
 }
+
+# CIDR per la Function App: Signature
+resource "dx_available_subnet_cidr" "signature_fa_subnet_cidr" {
+  virtual_network_id = module.azure_core_infra.common_vnet.id
+  prefix_length      = 24
+  depends_on         = [module.auth_function]
+}

--- a/infra/resources/prod/signature.tf
+++ b/infra/resources/prod/signature.tf
@@ -1,0 +1,42 @@
+# =============================================================================
+# Signature Validation - Azure Function
+# =============================================================================
+
+module "signature_function" {
+  source = "../_modules/function_app"
+
+  environment = merge(local.environment, {
+    app_name        = "sig",
+    instance_number = "01"
+  })
+
+  application_insights_connection_string = data.azurerm_key_vault_secret.appinsights_connection_string.value
+  application_insights_key               = data.azurerm_key_vault_secret.appinsights_instrumentationkey.value
+
+  resource_group_name = azurerm_resource_group.fn_rg.name
+  tags                = local.tags
+
+  virtual_network = {
+    name                = module.azure_core_infra.common_vnet.name
+    resource_group_name = module.azure_core_infra.network_resource_group_name
+  }
+  subnet_pep_id = module.azure_core_infra.common_pep_snet.id
+  subnet_cidr   = dx_available_subnet_cidr.signature_fa_subnet_cidr.cidr_block
+
+  health_check_path = "/api/v1/health"
+  node_version      = 22
+  app_settings      = merge(local.common_app_settings, local.signature_func_app_settings)
+  slot_app_settings = merge(local.common_app_settings, local.signature_slot_func_app_settings)
+
+  depends_on = [module.azure_core_infra]
+}
+
+# -----------------------------------------------------------------------------
+# Role Assignments
+# -----------------------------------------------------------------------------
+
+resource "azurerm_role_assignment" "cd_identity_website_contributor_signature_func" {
+  scope                = module.signature_function.function_app_id
+  role_definition_name = "Website Contributor"
+  principal_id         = data.azurerm_user_assigned_identity.github_cd_identity.principal_id
+}

--- a/infra/resources/prod/tfmodules.lock.json
+++ b/infra/resources/prod/tfmodules.lock.json
@@ -58,5 +58,11 @@
     "version": "3.0.0",
     "name": "azure_function_app",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/3.0.0"
+  },
+  "signature_function.azurerm_linux_function_app": {
+    "hash": "a38c42efbd1577c3971123cc4f335a6827e0ead44695b9d014789e0598c2672d",
+    "version": "3.0.0",
+    "name": "azure_function_app",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/3.0.0"
   }
 }

--- a/infra/scripts/generate_locals.py
+++ b/infra/scripts/generate_locals.py
@@ -178,6 +178,22 @@ def render_map(settings: dict, indent: int = 4) -> str:
     return "{\n" + rows + f"\n{' ' * (indent - 2)}}}"
 
 
+def hcl_string(value) -> str:
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def render_string_list(values: list, indent: int = 4) -> str:
+    """Serializza una lista Python come lista HCL Terraform di stringhe."""
+    if not values:
+        return "[]"
+    rows = "\n".join(
+        f"{' ' * indent}{hcl_string(value)},"
+        for value in values
+    )
+    return "[\n" + rows + f"\n{' ' * (indent - 2)}]"
+
+
 # ─── Parsing della sezione app ────────────────────────────────────────────────
 
 
@@ -221,6 +237,7 @@ def generate_app_block(app_key: str, app_cfg: dict) -> str:
         yaml_fe_smcr_slot_app_settings = { ... }   # o reference se identici
     """
     local_name = app_cfg["__local"]
+    sticky = app_cfg.get("__sticky", []) or []
     shared, prod_only, staging_only = split_settings(app_cfg)
 
     prod = {**shared, **prod_only}
@@ -253,6 +270,11 @@ def generate_app_block(app_key: str, app_cfg: dict) -> str:
         )
     else:
         lines.append(f"  {local_name}_slot_app_settings = {render_map(staging)}")
+
+    lines += [
+        "",
+        f"  {local_name}_sticky_app_setting_names = {render_string_list(sticky)}",
+    ]
 
     return "\n".join(lines)
 

--- a/infra/scripts/generate_locals.py
+++ b/infra/scripts/generate_locals.py
@@ -194,6 +194,17 @@ def render_string_list(values: list, indent: int = 4) -> str:
     return "[\n" + rows + f"\n{' ' * (indent - 2)}]"
 
 
+def parse_sticky_settings(app_key: str, app_cfg: dict) -> list[str]:
+    """Legge e valida la metachiave __sticky da una sezione YAML."""
+    sticky = app_cfg.get("__sticky", []) or []
+    if not isinstance(sticky, list):
+        raise TypeError(f"__sticky for {app_key} must be a list of strings")
+    invalid = [value for value in sticky if not isinstance(value, str)]
+    if invalid:
+        raise TypeError(f"__sticky for {app_key} must contain only strings")
+    return sticky
+
+
 # ─── Parsing della sezione app ────────────────────────────────────────────────
 
 
@@ -237,7 +248,7 @@ def generate_app_block(app_key: str, app_cfg: dict) -> str:
         yaml_fe_smcr_slot_app_settings = { ... }   # o reference se identici
     """
     local_name = app_cfg["__local"]
-    sticky = app_cfg.get("__sticky", []) or []
+    sticky = parse_sticky_settings(app_key, app_cfg)
     shared, prod_only, staging_only = split_settings(app_cfg)
 
     prod = {**shared, **prod_only}


### PR DESCRIPTION
## Descrizione

Cosa è stato fatto:

 - Supporto __sticky nello script `infra/scripts/generate_locals.py`
 - Nuovo local generato:

 ```
 yaml_fe_smcr_sticky_app_setting_names = [
   "SIGNATURE_FN_URL",
   "SIGNATURE_FN_KEY",
 ]
```
 - Wrapper `infra/resources/_modules/app_service` esteso con:
 **sticky_app_setting_names**
 - `app_fe_smcr.tf` ora passa gli sticky settings al modulo DX
 - `prod.yaml` contiene:
 ```
 SIGNATURE_FN_URL: "https://plsm-p-itn-sig-func-01.azurewebsites.net"
 SIGNATURE_FN_KEY: "kv:fe_smcr_signature_fn_key"
```

```
 __sticky:
   - SIGNATURE_FN_URL
   - SIGNATURE_FN_KEY
 ```
- Utilizzato sticky per fe-smcr per evitare problemi di swap staging-production:
```
fe_smcr:
  __local: yaml_fe_smcr
  __sticky:
    - SIGNATURE_FN_URL
    - SIGNATURE_FN_KEY
    - AUTH_FUNCTION_BASE_URL
    - AUTH_JWT_AUDIENCE
    - AUTH_JWT_ISSUER
    - NEXT_PUBLIC_APP_URL
    - NEXT_PUBLIC_POST_LOGIN_REDIRECT
```


Nota: questa PR include anche i file Terraform della signature function (`signature.tf`, subnet CIDR, lock module e locals) perché le risorse `plsm-p-itn-sig-func-01` sono già state applicate nello state. Senza questi file nel branch, il plan Terraform proporrebbe la distruzione delle risorse signature esistenti.