### PR TITLE
[SMION-799] Improve log

### DIFF
--- a/apps/sm-crm-fn/__tests__/appointmentPersistence.test.ts
+++ b/apps/sm-crm-fn/__tests__/appointmentPersistence.test.ts
@@ -1,0 +1,87 @@
+import { analyzeAppointmentPersistence } from "../_shared/services/appointments";
+
+describe("analyzeAppointmentPersistence", () => {
+  it("returns no issues when all verified fields are persisted", () => {
+    const sent = {
+      subject: "Call",
+      category: "Next step X",
+      pgp_oggettodelcontatto: 100000000,
+      sortdate: "2026-07-20T00:00:00Z",
+    };
+    const persisted = {
+      activityid: "id-1",
+      subject: "Call",
+      category: "Next step X",
+      pgp_oggettodelcontatto: 100000000,
+      sortdate: "2026-07-20T00:00:00Z",
+    };
+
+    expect(analyzeAppointmentPersistence(sent, persisted)).toEqual([]);
+  });
+
+  it("flags a field as missing when Dynamics returns null (es. field-level security)", () => {
+    const sent = { category: "Next step X", pgp_oggettodelcontatto: 100000000 };
+    const persisted = {
+      activityid: "id-1",
+      category: null,
+      pgp_oggettodelcontatto: 100000000,
+    };
+
+    const issues = analyzeAppointmentPersistence(sent, persisted);
+
+    expect(issues).toEqual([
+      {
+        field: "category",
+        sentValue: "Next step X",
+        persistedValue: null,
+        reason: "missing",
+      },
+    ]);
+  });
+
+  it("flags a field as overwritten when the persisted value differs", () => {
+    const sent = { pgp_oggettodelcontatto: 100000000 };
+    const persisted = {
+      activityid: "id-1",
+      pgp_oggettodelcontatto: 100000005,
+    };
+
+    const issues = analyzeAppointmentPersistence(sent, persisted);
+
+    expect(issues).toEqual([
+      {
+        field: "pgp_oggettodelcontatto",
+        sentValue: 100000000,
+        persistedValue: 100000005,
+        reason: "overwritten",
+      },
+    ]);
+  });
+
+  it("treats equivalent number and date formats as persisted", () => {
+    const sent = {
+      pgp_oggettodelcontatto: 100000000,
+      sortdate: "2026-07-20T00:00:00Z",
+    };
+    const persisted = {
+      activityid: "id-1",
+      pgp_oggettodelcontatto: "100000000",
+      sortdate: "2026-07-20T00:00:00+00:00",
+    };
+
+    expect(analyzeAppointmentPersistence(sent, persisted)).toEqual([]);
+  });
+
+  it("ignores fields not present in the sent payload", () => {
+    const sent = { subject: "Call" };
+    const persisted = { activityid: "id-1", subject: "Call", category: null };
+
+    expect(analyzeAppointmentPersistence(sent, persisted)).toEqual([]);
+  });
+
+  it("returns no issues when the representation is missing", () => {
+    const sent = { category: "Next step X" };
+
+    expect(analyzeAppointmentPersistence(sent, null)).toEqual([]);
+  });
+});

--- a/apps/sm-crm-fn/__tests__/appointmentPersistence.test.ts
+++ b/apps/sm-crm-fn/__tests__/appointmentPersistence.test.ts
@@ -84,4 +84,14 @@ describe("analyzeAppointmentPersistence", () => {
 
     expect(analyzeAppointmentPersistence(sent, null)).toEqual([]);
   });
+
+  it("returns no issues when the representation contains none of the verified fields (es. httpClient fallback {})", () => {
+    const sent = {
+      category: "Next step X",
+      pgp_oggettodelcontatto: 100000000,
+      sortdate: "2026-07-20T00:00:00Z",
+    };
+
+    expect(analyzeAppointmentPersistence(sent, {})).toEqual([]);
+  });
 });

--- a/apps/sm-crm-fn/_shared/services/appointments.ts
+++ b/apps/sm-crm-fn/_shared/services/appointments.ts
@@ -10,10 +10,127 @@ import type {
   ProductIdSelfcare,
 } from "../types/dynamics";
 import { get, post, buildUrl } from "./httpClient";
-import { type Logger } from "../utils/logger";
+import { type Logger, createLogger } from "../utils/logger";
 import { getProductGuid, resolveEnvironment } from "../utils/mappings";
-import type { DiagnosticSession } from "./diagnosticLogger";
+import type {
+  DiagnosticSession,
+  FieldPersistenceIssue,
+} from "./diagnosticLogger";
 import { addDiagnosticCall } from "./diagnosticLogger";
+
+/**
+ * Attributi scalari dell'appuntamento di cui verificare la persistenza reale
+ * confrontando il payload inviato con la rappresentazione restituita da Dynamics.
+ * Sono i campi "di business" più soggetti a scarto silenzioso (field-level
+ * security, campi read-only, plugin/business rule): oggetto del contatto,
+ * categoria/next step e data prossimo contatto.
+ */
+const APPOINTMENT_FIELDS_TO_VERIFY = [
+  "subject",
+  "location",
+  "description",
+  "statuscode",
+  "pgp_oggettodelcontatto",
+  "category",
+  "sortdate",
+] as const;
+
+/**
+ * Confronta due valori in modo tollerante ai formati equivalenti.
+ * Gestisce numeri rappresentati come stringa e date ISO con formattazioni
+ * diverse (es. "2026-07-20T00:00:00Z" vs "2026-07-20T00:00:00+00:00").
+ *
+ * @param sent - Valore inviato nel payload
+ * @param persisted - Valore restituito da Dynamics
+ * @returns true se i due valori sono da considerarsi equivalenti
+ */
+function valuesEquivalent(sent: unknown, persisted: unknown): boolean {
+  if (sent === persisted) {
+    return true;
+  }
+
+  if (sent == null || persisted == null) {
+    return false;
+  }
+
+  const sentNumber = Number(sent);
+  const persistedNumber = Number(persisted);
+  if (
+    !Number.isNaN(sentNumber) &&
+    !Number.isNaN(persistedNumber) &&
+    `${sent}`.trim() !== "" &&
+    `${persisted}`.trim() !== ""
+  ) {
+    return sentNumber === persistedNumber;
+  }
+
+  const sentTime = Date.parse(String(sent));
+  const persistedTime = Date.parse(String(persisted));
+  if (!Number.isNaN(sentTime) && !Number.isNaN(persistedTime)) {
+    return sentTime === persistedTime;
+  }
+
+  return String(sent) === String(persisted);
+}
+
+/**
+ * Verifica quali attributi inviati nel payload dell'appuntamento NON risultano
+ * nella rappresentazione restituita da Dynamics 365 (grazie all'header
+ * `Prefer: return=representation`), individuando campi scartati o sovrascritti.
+ *
+ * È lo strumento chiave per capire, senza accedere direttamente al CRM, perché
+ * alcuni campi (es. `category`, `pgp_oggettodelcontatto`) risultano non salvati
+ * pur ricevendo una risposta di successo.
+ *
+ * @param sentBody - Payload OData inviato alla POST /appointments
+ * @param persisted - Rappresentazione del record restituita da Dynamics
+ * @returns Elenco delle discrepanze rilevate (vuoto se tutto persistito)
+ */
+export function analyzeAppointmentPersistence(
+  sentBody: Record<string, unknown>,
+  persisted: unknown,
+): FieldPersistenceIssue[] {
+  if (!persisted || typeof persisted !== "object") {
+    return [];
+  }
+
+  const persistedRecord = persisted as Record<string, unknown>;
+  const issues: FieldPersistenceIssue[] = [];
+
+  for (const field of APPOINTMENT_FIELDS_TO_VERIFY) {
+    if (!(field in sentBody)) {
+      continue;
+    }
+
+    const sentValue = sentBody[field];
+    if (sentValue === undefined) {
+      continue;
+    }
+
+    const persistedValue = persistedRecord[field];
+
+    if (persistedValue === undefined || persistedValue === null) {
+      issues.push({
+        field,
+        sentValue,
+        persistedValue: persistedValue ?? null,
+        reason: "missing",
+      });
+      continue;
+    }
+
+    if (!valuesEquivalent(sentValue, persistedValue)) {
+      issues.push({
+        field,
+        sentValue,
+        persistedValue,
+        reason: "overwritten",
+      });
+    }
+  }
+
+  return issues;
+}
 
 // -----------------------------------------------------------------------------
 // Lista Appuntamenti
@@ -209,6 +326,7 @@ export async function createAppointment(
   );
 
   const timer = Date.now();
+  const logger = createLogger();
   const executeCreateAppointment = async (
     requestBody: CreateAppointmentRequest,
     step: string,
@@ -222,6 +340,39 @@ export async function createAppointment(
         params.baseUrl,
       );
 
+      // Verifica quali campi inviati risultano effettivamente persistiti nella
+      // rappresentazione restituita da Dynamics (Prefer: return=representation).
+      const persistenceIssues = analyzeAppointmentPersistence(
+        requestBody as unknown as Record<string, unknown>,
+        result,
+      );
+
+      if (persistenceIssues.length > 0) {
+        logger.warn(
+          "[Appointments] Alcuni campi inviati NON risultano persistiti in Dynamics",
+          {
+            activityId: (result as Appointment).activityid,
+            step,
+            droppedFields: persistenceIssues.map((issue) => issue.field),
+            persistenceIssues,
+          },
+        );
+
+        if (params.diagnosticSession) {
+          params.diagnosticSession.flowSummary.persistenceIssues =
+            persistenceIssues;
+        }
+      } else {
+        logger.info(
+          "[Appointments] Tutti i campi verificati risultano persistiti in Dynamics",
+          {
+            activityId: (result as Appointment).activityid,
+            step,
+            verifiedFields: [...APPOINTMENT_FIELDS_TO_VERIFY],
+          },
+        );
+      }
+
       if (params.diagnosticSession) {
         addDiagnosticCall(params.diagnosticSession, {
           step,
@@ -233,6 +384,7 @@ export async function createAppointment(
           requestBody,
           derivedFromFrontend: appointmentDerivedFromFrontend,
           responseStatus: 201,
+          responseBody: result,
           durationMs: Date.now() - attemptStart,
           success: true,
         });

--- a/apps/sm-crm-fn/_shared/services/appointments.ts
+++ b/apps/sm-crm-fn/_shared/services/appointments.ts
@@ -95,6 +95,17 @@ export function analyzeAppointmentPersistence(
   }
 
   const persistedRecord = persisted as Record<string, unknown>;
+
+  // Se la rappresentazione restituita non contiene NESSUNO dei campi verificati
+  // (es. httpClient.post fa fallback a {} su 204 o su parsing JSON fallito),
+  // non possiamo dedurre la persistenza: evitiamo falsi positivi "missing".
+  const hasAnyVerifiedField = APPOINTMENT_FIELDS_TO_VERIFY.some(
+    (field) => field in persistedRecord,
+  );
+  if (!hasAnyVerifiedField) {
+    return [];
+  }
+
   const issues: FieldPersistenceIssue[] = [];
 
   for (const field of APPOINTMENT_FIELDS_TO_VERIFY) {
@@ -354,7 +365,7 @@ export async function createAppointment(
             activityId: (result as Appointment).activityid,
             step,
             droppedFields: persistenceIssues.map((issue) => issue.field),
-            persistenceIssues,
+            issuesCount: persistenceIssues.length,
           },
         );
 

--- a/apps/sm-crm-fn/_shared/services/diagnosticLogger.ts
+++ b/apps/sm-crm-fn/_shared/services/diagnosticLogger.ts
@@ -82,12 +82,46 @@ export interface DiagnosticCall {
   derivedFromFrontend?: DiagnosticDerivedFromFrontend;
   /** HTTP status code ricevuto (null se la chiamata ha lanciato eccezione) */
   responseStatus: number | null;
+  /**
+   * Body restituito da Dynamics 365 (rappresentazione del record persistito).
+   * Popolato solo per le POST andate a buon fine quando l'header
+   * `Prefer: return=representation` è attivo: contiene il record ESATTO
+   * come salvato da Dynamics, utile per verificare quali campi sono stati
+   * effettivamente scritti senza accedere direttamente al CRM.
+   */
+  responseBody?: unknown;
   /** Durata della chiamata in millisecondi */
   durationMs: number;
   /** Indica se la chiamata ha avuto successo logico */
   success?: boolean;
   /** Messaggio di errore se la chiamata è fallita */
   error?: string;
+}
+
+/**
+ * Motivo per cui un campo inviato a Dynamics non risulta persistito
+ * nella rappresentazione restituita.
+ * - `missing`: il campo era presente nel payload ma è null/assente nel record salvato
+ *   (tipico di field-level security mancante o campo read-only ignorato).
+ * - `overwritten`: il campo è stato salvato con un valore diverso da quello inviato
+ *   (tipico di plugin/business rule/workflow che sovrascrivono il valore).
+ */
+export type FieldPersistenceReason = "missing" | "overwritten";
+
+/**
+ * Esito della verifica di persistenza di un singolo campo dell'appuntamento,
+ * ottenuto confrontando il payload inviato con la rappresentazione restituita
+ * da Dynamics 365.
+ */
+export interface FieldPersistenceIssue {
+  /** Nome dell'attributo Dynamics verificato (es. "category", "pgp_oggettodelcontatto") */
+  field: string;
+  /** Valore inviato nel payload della POST */
+  sentValue: unknown;
+  /** Valore effettivamente persistito e restituito da Dynamics */
+  persistedValue: unknown;
+  /** Motivo della discrepanza */
+  reason: FieldPersistenceReason;
 }
 
 /**
@@ -131,6 +165,14 @@ export interface DiagnosticFlowSummary {
     status: "started" | "completed" | "failed";
     summary: string;
   }>;
+  /**
+   * Esito della verifica di persistenza dei campi dell'appuntamento.
+   * Elenca i campi inviati a Dynamics che NON risultano nella rappresentazione
+   * restituita (mancanti) o che sono stati salvati con un valore diverso
+   * (sovrascritti). Vuoto/assente quando tutti i campi inviati sono stati
+   * persistiti correttamente.
+   */
+  persistenceIssues?: FieldPersistenceIssue[];
   /** Risultato finale dell'orchestrazione (popolato a fine flusso) */
   result?: unknown;
 }
@@ -256,7 +298,9 @@ function sanitizeDiagnosticValue(
     if (ancestors.includes(value)) {
       return "[Circular]";
     }
-    return value.map((item) => sanitizeDiagnosticValue(item, undefined, [...ancestors, value]));
+    return value.map((item) =>
+      sanitizeDiagnosticValue(item, undefined, [...ancestors, value]),
+    );
   }
 
   if (value && typeof value === "object") {
@@ -297,6 +341,7 @@ function buildPersistedDiagnosticSession(
         "requestDetails",
       ) as DiagnosticRequestDetails | undefined,
       requestBody: sanitizeDiagnosticValue(call.requestBody, "requestBody"),
+      responseBody: sanitizeDiagnosticValue(call.responseBody, "responseBody"),
       derivedFromFrontend: sanitizeDiagnosticValue(
         call.derivedFromFrontend,
         "derivedFromFrontend",

--- a/apps/sm-crm-fn/_shared/services/httpClient.ts
+++ b/apps/sm-crm-fn/_shared/services/httpClient.ts
@@ -309,6 +309,14 @@ export async function post<TRequest, TResponse>(
 
     logHttpResponse(logger, "POST", url, response.status, duration);
 
+    // Traccia la rappresentazione persistita restituita da Dynamics
+    // (header Prefer: return=representation): consente di verificare quali
+    // campi sono stati effettivamente salvati senza accedere al CRM.
+    logger.debug("POST persisted representation", {
+      url,
+      representation: data,
+    });
+
     return data as TResponse;
   } catch (error) {
     const duration = timer.elapsed();

--- a/apps/sm-crm-fn/contacts/index.ts
+++ b/apps/sm-crm-fn/contacts/index.ts
@@ -2,20 +2,29 @@
 // CONTACTS INDEX - Azure Function Definition
 // =============================================================================
 
-import { app } from "@azure/functions";
+import { HttpRequest, InvocationContext, app } from "@azure/functions";
 import { getContactsHandler } from "./handler";
 import { createContactsHandler } from "./createHandler";
 
-app.http("getContacts", {
-  methods: ["GET"],
+/**
+ * GET|POST /api/contacts
+ *
+ * Nel modello di programmazione Azure Functions Node v4 due funzioni distinte
+ * che condividono la stessa `route` non generano una route multi-metodo: la
+ * prima registrata "vince" e la seconda viene oscurata (404). Per questo GET e
+ * POST sullo stesso path devono essere registrati in un'unica funzione che
+ * smista in base al metodo HTTP.
+ *
+ * @param request Richiesta HTTP in ingresso.
+ * @param context Contesto di invocazione della Function.
+ * @returns Risposta del handler POST (creazione) o GET (lettura).
+ */
+app.http("contacts", {
+  methods: ["GET", "POST"],
   authLevel: "function",
   route: "contacts",
-  handler: getContactsHandler,
-});
-
-app.http("createContacts", {
-  methods: ["POST"],
-  authLevel: "function",
-  route: "contacts",
-  handler: createContactsHandler,
+  handler: (request: HttpRequest, context: InvocationContext) =>
+    request.method === "POST"
+      ? createContactsHandler(request, context)
+      : getContactsHandler(request, context),
 });

--- a/apps/sm-crm-fn/meetings/index.ts
+++ b/apps/sm-crm-fn/meetings/index.ts
@@ -2,27 +2,34 @@
 // MEETINGS INDEX - Registrazione Azure Functions
 // =============================================================================
 
-import { app } from "@azure/functions";
+import { HttpRequest, InvocationContext, app } from "@azure/functions";
 import {
   createMeetingHandler,
   listMeetingsHandler,
   dryRunMeetingHandler,
 } from "./handler";
 
-// POST /api/meetings - Crea appuntamento
-app.http("createMeeting", {
-  methods: ["POST"],
+/**
+ * GET|POST /api/meetings
+ *
+ * Nel modello di programmazione Azure Functions Node v4 due funzioni distinte
+ * che condividono la stessa `route` non generano una route multi-metodo: la
+ * prima registrata "vince" e la seconda viene oscurata (404). Per questo GET e
+ * POST sullo stesso path devono essere registrati in un'unica funzione che
+ * smista in base al metodo HTTP.
+ *
+ * @param request Richiesta HTTP in ingresso.
+ * @param context Contesto di invocazione della Function.
+ * @returns Risposta del handler POST (creazione) o GET (lista).
+ */
+app.http("meetings", {
+  methods: ["GET", "POST"],
   authLevel: "function",
   route: "meetings",
-  handler: createMeetingHandler,
-});
-
-// GET /api/meetings - Lista appuntamenti
-app.http("listMeetings", {
-  methods: ["GET"],
-  authLevel: "function",
-  route: "meetings",
-  handler: listMeetingsHandler,
+  handler: (request: HttpRequest, context: InvocationContext) =>
+    request.method === "POST"
+      ? createMeetingHandler(request, context)
+      : listMeetingsHandler(request, context),
 });
 
 // POST /api/meetings/dry-run - Test senza modifiche


### PR DESCRIPTION
Questa PR serve per aumentare le informazioni registrate nel log.in `crm-diagnostics` da parte della funzione `plsm-p-itn-crm-func-01`. Ovviamente va abilitato l'env: `DIAGNOSTIC_LOGGING_ENABLED` a true.