### PR TITLE
[SMION-800] Propagazione errori CRM al frontend

### DIFF
--- a/apps/sm-crm-fn/__tests__/crmError.test.ts
+++ b/apps/sm-crm-fn/__tests__/crmError.test.ts
@@ -1,0 +1,22 @@
+import { CrmError } from "../_shared/errors/CrmError";
+
+describe("CrmError", () => {
+  it("keeps rawDetail out of the default message", () => {
+    const err = new CrmError({
+      status: 500,
+      odataCode: "0x80040265",
+      rawDetail: "SECRET raw OData body with https://internal.crm.example/api",
+    });
+
+    expect(err.message).not.toContain("SECRET");
+    expect(err.message).not.toContain("https://");
+    expect(err.message).not.toContain("0x80040265");
+    expect(err.rawDetail).toContain("SECRET");
+  });
+
+  it("uses an explicit message only when provided, still never forced to include rawDetail", () => {
+    const err = new CrmError({ status: 503 });
+
+    expect(err.message).toBe("CRM request failed (status 503)");
+  });
+});

--- a/apps/sm-crm-fn/__tests__/crmErrorMapper.test.ts
+++ b/apps/sm-crm-fn/__tests__/crmErrorMapper.test.ts
@@ -1,0 +1,72 @@
+import { mapCrmError } from "../_shared/services/crmErrorMapper";
+import { CrmError } from "../_shared/errors/CrmError";
+
+describe("mapCrmError", () => {
+  it("classifies verifyAccount failures as ACCOUNT_NOT_FOUND", () => {
+    expect(mapCrmError({ step: "verifyAccount" })).toEqual({
+      code: "ACCOUNT_NOT_FOUND",
+      category: "NOT_FOUND",
+      step: "verifyAccount",
+    });
+  });
+
+  it("classifies verifyOrCreateContacts failures as CONTACT_INVALID", () => {
+    expect(mapCrmError({ step: "verifyOrCreateContacts" })).toEqual({
+      code: "CONTACT_INVALID",
+      category: "NOT_FOUND",
+      step: "verifyOrCreateContacts",
+    });
+  });
+
+  it("classifies a Dynamics field-rejection OData code as CRM_FIELD_REJECTED", () => {
+    const error = new CrmError({
+      status: 400,
+      odataCode: "0x80040265",
+      rawDetail: "The entity field xyz is invalid",
+      step: "createAppointment",
+    });
+    expect(mapCrmError({ step: "createAppointment", error })).toEqual({
+      code: "CRM_FIELD_REJECTED",
+      category: "CRM_REJECTED",
+      step: "createAppointment",
+    });
+  });
+
+  it("classifies Dynamics 5xx as CRM_UNAVAILABLE", () => {
+    const error = new CrmError({ status: 503, step: "createAppointment" });
+    expect(mapCrmError({ step: "createAppointment", error })).toEqual({
+      code: "CRM_UNAVAILABLE",
+      category: "CRM_UNAVAILABLE",
+      step: "createAppointment",
+    });
+  });
+
+  it("falls back to CRM_ERROR for an unclassified createAppointment failure", () => {
+    const error = new CrmError({ status: 400, step: "createAppointment" });
+    expect(mapCrmError({ step: "createAppointment", error })).toEqual({
+      code: "CRM_ERROR",
+      category: "UNKNOWN",
+      step: "createAppointment",
+    });
+  });
+
+  it("falls back to UNKNOWN for an unrecognised step without error", () => {
+    expect(mapCrmError({ step: "somethingElse" })).toEqual({
+      code: "UNKNOWN",
+      category: "UNKNOWN",
+      step: "somethingElse",
+    });
+  });
+
+  it("never leaks rawDetail into the mapped output", () => {
+    const error = new CrmError({
+      status: 400,
+      odataCode: "0x80040265",
+      rawDetail: "SECRET schema attribute pgp_internal",
+      step: "createAppointment",
+    });
+    const result = mapCrmError({ step: "createAppointment", error });
+    expect(JSON.stringify(result)).not.toContain("SECRET");
+    expect(JSON.stringify(result)).not.toContain("rawDetail");
+  });
+});

--- a/apps/sm-crm-fn/__tests__/meetingsHandler.test.ts
+++ b/apps/sm-crm-fn/__tests__/meetingsHandler.test.ts
@@ -10,9 +10,13 @@ jest.mock("../_shared/services/orchestrator", () => ({
 }));
 
 const mockedCreateMeetingOrchestrator =
-  createMeetingOrchestrator as jest.MockedFunction<typeof createMeetingOrchestrator>;
+  createMeetingOrchestrator as jest.MockedFunction<
+    typeof createMeetingOrchestrator
+  >;
 const mockedValidateOrchestratorRequest =
-  validateOrchestratorRequest as jest.MockedFunction<typeof validateOrchestratorRequest>;
+  validateOrchestratorRequest as jest.MockedFunction<
+    typeof validateOrchestratorRequest
+  >;
 
 function makeRequest(body: unknown) {
   return {
@@ -35,10 +39,16 @@ describe("createMeetingHandler", () => {
     jest.clearAllMocks();
   });
 
-  it("emits a neutral error object for validation failures", async () => {
+  it("emits a neutral error object with per-field detail for validation failures", async () => {
     mockedValidateOrchestratorRequest.mockReturnValue({
       valid: false,
-      errors: ["subject is required"],
+      fields: [
+        {
+          field: "subject",
+          code: "required",
+          message: "subject è obbligatorio",
+        },
+      ],
     } as ReturnType<typeof validateOrchestratorRequest>);
 
     const response = await createMeetingHandler(
@@ -50,11 +60,17 @@ describe("createMeetingHandler", () => {
     expect(response.jsonBody).toMatchObject({
       success: false,
       message: "Errore di validazione",
-      errors: ["subject is required"],
       error: {
         code: "VALIDATION_ERROR",
         category: "VALIDATION",
         step: "validation",
+        fields: [
+          {
+            field: "subject",
+            code: "required",
+            message: "subject è obbligatorio",
+          },
+        ],
       },
     });
   });

--- a/apps/sm-crm-fn/__tests__/meetingsHandler.test.ts
+++ b/apps/sm-crm-fn/__tests__/meetingsHandler.test.ts
@@ -1,0 +1,117 @@
+import { createMeetingHandler } from "../meetings/handler";
+import {
+  createMeetingOrchestrator,
+  validateOrchestratorRequest,
+} from "../_shared/services/orchestrator";
+
+jest.mock("../_shared/services/orchestrator", () => ({
+  createMeetingOrchestrator: jest.fn(),
+  validateOrchestratorRequest: jest.fn(),
+}));
+
+const mockedCreateMeetingOrchestrator =
+  createMeetingOrchestrator as jest.MockedFunction<typeof createMeetingOrchestrator>;
+const mockedValidateOrchestratorRequest =
+  validateOrchestratorRequest as jest.MockedFunction<typeof validateOrchestratorRequest>;
+
+function makeRequest(body: unknown) {
+  return {
+    headers: { get: jest.fn().mockReturnValue(null) },
+    json: jest.fn().mockResolvedValue(body),
+  };
+}
+
+function makeContext() {
+  return {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+describe("createMeetingHandler", () => {
+  beforeEach(() => {
+    process.env.DYNAMICS_BASE_URL = "https://org.crm4.dynamics.com";
+    jest.clearAllMocks();
+  });
+
+  it("emits a neutral error object for validation failures", async () => {
+    mockedValidateOrchestratorRequest.mockReturnValue({
+      valid: false,
+      errors: ["subject is required"],
+    } as ReturnType<typeof validateOrchestratorRequest>);
+
+    const response = await createMeetingHandler(
+      makeRequest({}) as never,
+      makeContext() as never,
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.jsonBody).toMatchObject({
+      success: false,
+      message: "Errore di validazione",
+      errors: ["subject is required"],
+      error: {
+        code: "VALIDATION_ERROR",
+        category: "VALIDATION",
+        step: "validation",
+      },
+    });
+  });
+
+  it("mirrors orchestrator errorInfo as top-level error for failed orchestration", async () => {
+    const errorInfo = {
+      code: "ACCOUNT_NOT_FOUND",
+      category: "NOT_FOUND",
+      step: "verifyAccount",
+    } as const;
+    mockedValidateOrchestratorRequest.mockReturnValue({
+      valid: true,
+      data: { dryRun: false },
+    } as ReturnType<typeof validateOrchestratorRequest>);
+    mockedCreateMeetingOrchestrator.mockResolvedValue({
+      success: false,
+      dryRun: false,
+      steps: [],
+      warnings: [],
+      errorInfo,
+      timestamp: "2026-07-10T08:00:00.000Z",
+    });
+
+    const response = await createMeetingHandler(
+      makeRequest({ subject: "Call" }) as never,
+      makeContext() as never,
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.jsonBody).toMatchObject({
+      success: false,
+      errorInfo,
+      error: errorInfo,
+      message: "Errore durante la creazione dell'appuntamento",
+    });
+  });
+
+  it("emits a neutral error object without raw exception text for unexpected failures", async () => {
+    const rawErrorMessage = "SECRET Dynamics exception detail";
+    const response = await createMeetingHandler(
+      {
+        headers: { get: jest.fn().mockReturnValue(null) },
+        json: jest.fn().mockRejectedValue(new Error(rawErrorMessage)),
+      } as never,
+      makeContext() as never,
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.jsonBody).toMatchObject({
+      success: false,
+      message: "Errore interno del server",
+      error: {
+        code: "CRM_ERROR",
+        category: "UNKNOWN",
+        step: "unexpected",
+      },
+    });
+    expect(JSON.stringify(response.jsonBody)).not.toContain(rawErrorMessage);
+  });
+});

--- a/apps/sm-crm-fn/__tests__/meetingsHandler.test.ts
+++ b/apps/sm-crm-fn/__tests__/meetingsHandler.test.ts
@@ -92,6 +92,47 @@ describe("createMeetingHandler", () => {
     });
   });
 
+  it("does not leak raw CRM detail from failed orchestration result steps or warnings", async () => {
+    const errorInfo = {
+      code: "ACCOUNT_NOT_FOUND",
+      category: "NOT_FOUND",
+      step: "verifyAccount",
+    } as const;
+    mockedValidateOrchestratorRequest.mockReturnValue({
+      valid: true,
+      data: { dryRun: false },
+    } as ReturnType<typeof validateOrchestratorRequest>);
+    mockedCreateMeetingOrchestrator.mockResolvedValue({
+      success: false,
+      dryRun: false,
+      steps: [
+        {
+          step: "verifyAccount",
+          success: false,
+          error: "Errore durante la verifica dell'ente",
+          dryRun: false,
+        },
+      ],
+      warnings: ["Errore non gestito durante l'elaborazione"],
+      errorInfo,
+      timestamp: new Date().toISOString(),
+    });
+
+    const response = await createMeetingHandler(
+      makeRequest({ subject: "Call" }) as never,
+      makeContext() as never,
+    );
+
+    const serializedBody = JSON.stringify(response.jsonBody);
+    expect(serializedBody).not.toContain("https://");
+    expect(serializedBody).not.toContain("0x8004");
+    expect(serializedBody).not.toContain("failed: ");
+    expect(serializedBody).not.toContain("Exception during");
+    expect(response.jsonBody).toMatchObject({
+      error: errorInfo,
+    });
+  });
+
   it("emits a neutral error object without raw exception text for unexpected failures", async () => {
     const rawErrorMessage = "SECRET Dynamics exception detail";
     const response = await createMeetingHandler(

--- a/apps/sm-crm-fn/_shared/errors/CrmError.ts
+++ b/apps/sm-crm-fn/_shared/errors/CrmError.ts
@@ -1,0 +1,28 @@
+/**
+ * Errore tipizzato per fallimenti provenienti da Dynamics 365.
+ *
+ * Trasporta il contesto tecnico grezzo (status HTTP, codice OData, testo grezzo)
+ * verso i layer superiori SENZA esporlo nella risposta HTTP: il `rawDetail` è
+ * destinato esclusivamente ai log server-side (App Insights / DiagnosticSession).
+ */
+export class CrmError extends Error {
+  readonly status: number;
+  readonly odataCode?: string;
+  readonly rawDetail?: string;
+  step?: string;
+
+  constructor(params: {
+    status: number;
+    odataCode?: string;
+    rawDetail?: string;
+    step?: string;
+    message?: string;
+  }) {
+    super(params.message ?? `CRM request failed (status ${params.status})`);
+    this.name = "CrmError";
+    this.status = params.status;
+    this.odataCode = params.odataCode;
+    this.rawDetail = params.rawDetail;
+    this.step = params.step;
+  }
+}

--- a/apps/sm-crm-fn/_shared/services/appointments.ts
+++ b/apps/sm-crm-fn/_shared/services/appointments.ts
@@ -17,6 +17,7 @@ import type {
   FieldPersistenceIssue,
 } from "./diagnosticLogger";
 import { addDiagnosticCall } from "./diagnosticLogger";
+import { CrmError } from "../errors/CrmError";
 
 /**
  * Attributi scalari dell'appuntamento di cui verificare la persistenza reale
@@ -432,9 +433,10 @@ export async function createAppointment(
     console.log(`[Appointments] Appuntamento creato: ${result.activityid}`);
     return result;
   } catch (error) {
+    const odataCode = error instanceof CrmError ? error.odataCode : undefined;
     const errorMessage = error instanceof Error ? error.message : String(error);
 
-    if (!errorMessage.includes("0x80040265")) {
+    if (odataCode !== "0x80040265" && !errorMessage.includes("0x80040265")) {
       throw error;
     }
 

--- a/apps/sm-crm-fn/_shared/services/crmErrorMapper.ts
+++ b/apps/sm-crm-fn/_shared/services/crmErrorMapper.ts
@@ -1,0 +1,49 @@
+import { CrmError } from "../errors/CrmError";
+import type { CrmErrorInfo } from "../types/dynamics";
+
+/**
+ * Codici OData Dynamics che indicano un valore/campo rifiutato dal CRM
+ * (schema, optionset, campo inesistente o non valido).
+ */
+const FIELD_REJECTION_ODATA_CODES = new Set<string>([
+  "0x80040265",
+  "0x80040217",
+  "0x8004431a",
+]);
+
+/**
+ * Classifica un fallimento CRM in un codice d'errore neutro e stabile.
+ *
+ * Funzione pura: non conosce HTTP né testi user-facing. Il `rawDetail`
+ * dell'eventuale CrmError NON viene mai incluso nell'output.
+ *
+ * @param params.step - Step del flusso in cui è avvenuto l'errore.
+ * @param params.error - Errore risalito (tipicamente un CrmError), opzionale.
+ * @returns Informazione d'errore neutra { code, category, step }.
+ */
+export function mapCrmError(params: {
+  step: string;
+  error?: unknown;
+}): CrmErrorInfo {
+  const { step, error } = params;
+
+  if (error instanceof CrmError) {
+    if (error.status >= 500 || error.status === 0) {
+      return { code: "CRM_UNAVAILABLE", category: "CRM_UNAVAILABLE", step };
+    }
+    if (error.odataCode && FIELD_REJECTION_ODATA_CODES.has(error.odataCode)) {
+      return { code: "CRM_FIELD_REJECTED", category: "CRM_REJECTED", step };
+    }
+  }
+
+  switch (step) {
+    case "verifyAccount":
+      return { code: "ACCOUNT_NOT_FOUND", category: "NOT_FOUND", step };
+    case "verifyOrCreateContacts":
+      return { code: "CONTACT_INVALID", category: "NOT_FOUND", step };
+    case "createAppointment":
+      return { code: "CRM_ERROR", category: "UNKNOWN", step };
+    default:
+      return { code: "UNKNOWN", category: "UNKNOWN", step };
+  }
+}

--- a/apps/sm-crm-fn/_shared/services/httpClient.ts
+++ b/apps/sm-crm-fn/_shared/services/httpClient.ts
@@ -156,13 +156,27 @@ export async function get<T>(
 
     if (!response.ok) {
       const errorBody = await response.text();
+      let odataCode: string | undefined;
+      try {
+        const parsed = JSON.parse(errorBody) as {
+          error?: { code?: string };
+        };
+        odataCode = parsed.error?.code;
+      } catch {
+        odataCode = undefined;
+      }
+      // rawDetail resta SOLO nei log server-side, mai nella risposta HTTP.
       logger.error(`GET request failed`, new Error(errorBody), {
         url,
         statusCode: response.status,
         duration,
         method: "GET",
       });
-      throw new Error(`GET ${url} failed: ${response.status} - ${errorBody}`);
+      throw new CrmError({
+        status: response.status,
+        odataCode,
+        rawDetail: errorBody,
+      });
     }
 
     const data = await response.json();
@@ -298,7 +312,6 @@ export async function post<TRequest, TResponse>(
         status: response.status,
         odataCode,
         rawDetail: errorBody,
-        message: `POST ${url} failed: ${response.status}`,
       });
     }
 

--- a/apps/sm-crm-fn/_shared/services/httpClient.ts
+++ b/apps/sm-crm-fn/_shared/services/httpClient.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { getAccessToken, buildScope } from "./auth";
 import { getConfigOrThrow } from "../utils/config";
 import type { DynamicsList } from "../types/dynamics";
+import { CrmError } from "../errors/CrmError";
 import {
   createLogger,
   logHttpRequest,
@@ -277,13 +278,28 @@ export async function post<TRequest, TResponse>(
 
     if (!response.ok) {
       const errorBody = await response.text();
+      let odataCode: string | undefined;
+      try {
+        const parsed = JSON.parse(errorBody) as {
+          error?: { code?: string };
+        };
+        odataCode = parsed.error?.code;
+      } catch {
+        odataCode = undefined;
+      }
+      // rawDetail resta SOLO nei log server-side, mai nella risposta HTTP.
       logger.error(`POST request failed`, new Error(errorBody), {
         url,
         statusCode: response.status,
         duration,
         method: "POST",
       });
-      throw new Error(`POST ${url} failed: ${response.status} - ${errorBody}`);
+      throw new CrmError({
+        status: response.status,
+        odataCode,
+        rawDetail: errorBody,
+        message: `POST ${url} failed: ${response.status}`,
+      });
     }
 
     // Per GrantAccess la response è 204 No Content

--- a/apps/sm-crm-fn/_shared/services/orchestrator.ts
+++ b/apps/sm-crm-fn/_shared/services/orchestrator.ts
@@ -153,7 +153,7 @@ export async function createMeetingOrchestrator(
       steps.push({
         step: "verifyAccount",
         success: false,
-        error: `Exception during account verification: ${msg}`,
+        error: "Errore durante la verifica dell'ente",
         dryRun,
       });
 
@@ -437,7 +437,7 @@ export async function createMeetingOrchestrator(
       steps.push({
         step: "verifyOrCreateContacts",
         success: false,
-        error: `Exception during contact processing: ${msg}`,
+        error: "Errore durante la verifica o creazione dei contatti",
         dryRun,
       });
 
@@ -552,7 +552,7 @@ export async function createMeetingOrchestrator(
       steps.push({
         step: "createAppointment",
         success: false,
-        error: msg,
+        error: "Errore durante la creazione dell'appuntamento",
         dryRun,
       });
 
@@ -619,7 +619,6 @@ export async function createMeetingOrchestrator(
     return finalResponse;
   } catch (error) {
     // Catch globale per errori non gestiti
-    const msg = error instanceof Error ? error.message : String(error);
     const totalDuration = overallTimer.elapsed();
 
     logger.error("❌ ORCHESTRATOR UNHANDLED EXCEPTION", error, {
@@ -632,7 +631,7 @@ export async function createMeetingOrchestrator(
       steps.push({
         step: "unhandledException",
         success: false,
-        error: msg,
+        error: "Errore non gestito durante l'elaborazione",
         dryRun,
       });
     }
@@ -641,7 +640,7 @@ export async function createMeetingOrchestrator(
       success: false,
       dryRun,
       steps,
-      warnings: [...warnings, `Errore non gestito: ${msg}`],
+      warnings: [...warnings, "Errore non gestito durante l'elaborazione"],
       errorInfo: mapCrmError({ step: "unhandledException", error }),
       timestamp: new Date().toISOString(),
     };

--- a/apps/sm-crm-fn/_shared/services/orchestrator.ts
+++ b/apps/sm-crm-fn/_shared/services/orchestrator.ts
@@ -6,6 +6,7 @@ import type {
   CreateMeetingOrchestratorRequest,
   CreateMeetingOrchestratorResponse,
   CrmErrorInfo,
+  FieldValidationError,
   OrchestratorStepResult,
   ProductIdSelfcare,
   TipologiaReferente,
@@ -354,7 +355,9 @@ export async function createMeetingOrchestrator(
             email: partecipante.email,
             contactId: contactResult.contact?.contactid,
             status: contactResult.contact
-              ? (contactResult.created ? "created" : "found")
+              ? contactResult.created
+                ? "created"
+                : "found"
               : "failed",
           });
         }
@@ -492,7 +495,10 @@ export async function createMeetingOrchestrator(
       // Aggiorna flowSummary con binding appointment e finalDynamicsRequest
       if (diagnosticSession) {
         const productGuid = request.productIdSelfcare
-          ? getProductGuid(request.productIdSelfcare as ProductIdSelfcare, environment)
+          ? getProductGuid(
+              request.productIdSelfcare as ProductIdSelfcare,
+              environment,
+            )
           : null;
 
         diagnosticSession.flowSummary.derivedData.appointmentBindings = {
@@ -503,13 +509,15 @@ export async function createMeetingOrchestrator(
             : undefined,
         };
 
-        const appointmentCalls = diagnosticSession.dynamicsCalls
-          .filter((call) => call.entity === "appointments");
-        
+        const appointmentCalls = diagnosticSession.dynamicsCalls.filter(
+          (call) => call.entity === "appointments",
+        );
+
         diagnosticSession.flowSummary.finalDynamicsRequest = {
           method: "POST",
           url: `${request.baseUrl}/api/data/v9.2/appointments`,
-          requestBody: appointmentCalls[appointmentCalls.length - 1]?.requestBody,
+          requestBody:
+            appointmentCalls[appointmentCalls.length - 1]?.requestBody,
           derivedFromFrontend: {
             accountId,
             productIdSelfcare: request.productIdSelfcare,
@@ -709,20 +717,47 @@ async function buildErrorResponse(
 // Validazione request
 // -----------------------------------------------------------------------------
 
+/**
+ * Valida il payload di creazione appuntamento restituendo un dettaglio
+ * strutturato per singolo campo non valido.
+ *
+ * In caso di errori, ogni voce di `fields` riporta il percorso del campo
+ * (notazione a punti, es. `partecipanti.0.email`), un `code` macchina e un
+ * `message` leggibile, così da poter evidenziare il campo lato client.
+ *
+ * @param request - payload grezzo ricevuto dalla richiesta HTTP
+ * @returns `{ valid: true, data }` se valido, altrimenti `{ valid: false, fields }`
+ */
 export function validateOrchestratorRequest(
   request: unknown,
 ):
   | { valid: true; data: CreateMeetingOrchestratorRequest }
-  | { valid: false; errors: string[] } {
-  const errors: string[] = [];
+  | { valid: false; fields: FieldValidationError[] } {
+  const fields: FieldValidationError[] = [];
   const req = request as Record<string, unknown>;
 
+  const addFieldError = (
+    field: string,
+    code: FieldValidationError["code"],
+    message: string,
+  ): void => {
+    fields.push({ field, code, message });
+  };
+
   if (!req.institutionIdSelfcare && !req.nomeEnte) {
-    errors.push("Specificare almeno uno tra institutionIdSelfcare e nomeEnte");
+    addFieldError(
+      "institutionIdSelfcare",
+      "required",
+      "Specificare almeno uno tra institutionIdSelfcare e nomeEnte",
+    );
   }
 
   if (!req.productIdSelfcare) {
-    errors.push("productIdSelfcare è obbligatorio");
+    addFieldError(
+      "productIdSelfcare",
+      "required",
+      "productIdSelfcare è obbligatorio",
+    );
   }
 
   if (
@@ -730,13 +765,21 @@ export function validateOrchestratorRequest(
     !Array.isArray(req.partecipanti) ||
     req.partecipanti.length === 0
   ) {
-    errors.push("partecipanti deve essere un array non vuoto");
+    addFieldError(
+      "partecipanti",
+      "required",
+      "partecipanti deve essere un array non vuoto",
+    );
   } else {
     for (let i = 0; i < req.partecipanti.length; i++) {
       const p = req.partecipanti[i] as Record<string, unknown>;
 
       if (p.email !== undefined && typeof p.email !== "string") {
-        errors.push(`partecipanti[${i}].email deve essere una stringa`);
+        addFieldError(
+          `partecipanti.${i}.email`,
+          "invalid_type",
+          `partecipanti[${i}].email deve essere una stringa`,
+        );
         continue;
       }
 
@@ -747,7 +790,9 @@ export function validateOrchestratorRequest(
       ) {
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         if (!emailRegex.test(p.email)) {
-          errors.push(
+          addFieldError(
+            `partecipanti.${i}.email`,
+            "invalid_email",
             `partecipanti[${i}].email non è un indirizzo email valido`,
           );
         }
@@ -756,15 +801,19 @@ export function validateOrchestratorRequest(
   }
 
   if (!req.subject) {
-    errors.push("subject è obbligatorio");
+    addFieldError("subject", "required", "subject è obbligatorio");
   }
 
   if (!req.scheduledstart) {
-    errors.push("scheduledstart è obbligatorio");
+    addFieldError(
+      "scheduledstart",
+      "required",
+      "scheduledstart è obbligatorio",
+    );
   }
 
   if (!req.scheduledend) {
-    errors.push("scheduledend è obbligatorio");
+    addFieldError("scheduledend", "required", "scheduledend è obbligatorio");
   }
 
   /**
@@ -784,15 +833,17 @@ export function validateOrchestratorRequest(
   if (req.oggettoDelContatto !== undefined) {
     const val = Number(req.oggettoDelContatto);
     if (!Number.isInteger(val) || !VALID_OGGETTO_DEL_CONTATTO.includes(val)) {
-      errors.push(
+      addFieldError(
+        "oggettoDelContatto",
+        "invalid_value",
         `oggettoDelContatto non è valido: ricevuto ${req.oggettoDelContatto}. ` +
           `Valori ammessi: ${VALID_OGGETTO_DEL_CONTATTO.join(", ")}`,
       );
     }
   }
 
-  if (errors.length > 0) {
-    return { valid: false, errors };
+  if (fields.length > 0) {
+    return { valid: false, fields };
   }
 
   return {

--- a/apps/sm-crm-fn/_shared/services/orchestrator.ts
+++ b/apps/sm-crm-fn/_shared/services/orchestrator.ts
@@ -5,6 +5,7 @@
 import type {
   CreateMeetingOrchestratorRequest,
   CreateMeetingOrchestratorResponse,
+  CrmErrorInfo,
   OrchestratorStepResult,
   ProductIdSelfcare,
   TipologiaReferente,
@@ -20,6 +21,7 @@ import {
   isDiagnosticEnabled,
   type DiagnosticSession,
 } from "./diagnosticLogger";
+import { mapCrmError } from "./crmErrorMapper";
 import { resolveEnvironment, getProductGuid } from "../utils/mappings";
 
 // =============================================================================
@@ -168,6 +170,7 @@ export async function createMeetingOrchestrator(
         warnings,
         dryRun,
         `Errore durante verifica ente: ${msg}`,
+        mapCrmError({ step: "verifyAccount", error }),
         diagnosticSession,
       );
     }
@@ -198,6 +201,7 @@ export async function createMeetingOrchestrator(
         warnings,
         dryRun,
         accountResult.error ?? "Ente non trovato",
+        mapCrmError({ step: "verifyAccount" }),
         diagnosticSession,
       );
     }
@@ -397,6 +401,7 @@ export async function createMeetingOrchestrator(
           warnings,
           dryRun,
           "Nessun contatto valido trovato o creato",
+          mapCrmError({ step: "verifyOrCreateContacts" }),
           diagnosticSession,
         );
       }
@@ -449,6 +454,7 @@ export async function createMeetingOrchestrator(
         warnings,
         dryRun,
         `Errore durante verifica/creazione contatti: ${msg}`,
+        mapCrmError({ step: "verifyOrCreateContacts", error }),
         diagnosticSession,
       );
     }
@@ -563,6 +569,7 @@ export async function createMeetingOrchestrator(
         warnings,
         dryRun,
         `Errore creazione appuntamento: ${msg}`,
+        mapCrmError({ step: "createAppointment", error }),
         diagnosticSession,
       );
     }
@@ -635,6 +642,7 @@ export async function createMeetingOrchestrator(
       dryRun,
       steps,
       warnings: [...warnings, `Errore non gestito: ${msg}`],
+      errorInfo: mapCrmError({ step: "unhandledException", error }),
       timestamp: new Date().toISOString(),
     };
 
@@ -666,6 +674,7 @@ async function buildErrorResponse(
   warnings: string[],
   dryRun: boolean,
   errorMessage: string,
+  errorInfo: CrmErrorInfo,
   diagnosticSession?: DiagnosticSession,
 ): Promise<CreateMeetingOrchestratorResponse> {
   const logger = createLogger(undefined, { dryRun });
@@ -679,6 +688,7 @@ async function buildErrorResponse(
     dryRun,
     steps,
     warnings,
+    errorInfo,
     timestamp: new Date().toISOString(),
   };
 

--- a/apps/sm-crm-fn/_shared/types/dynamics.ts
+++ b/apps/sm-crm-fn/_shared/types/dynamics.ts
@@ -199,7 +199,30 @@ export interface CreateMeetingOrchestratorResponse {
   contactIds?: string[];
   steps: OrchestratorStepResult[];
   warnings: string[];
+  errorInfo?: CrmErrorInfo;
   timestamp: string;
+}
+
+export type CrmErrorCategory =
+  | "VALIDATION"
+  | "NOT_FOUND"
+  | "CRM_REJECTED"
+  | "CRM_UNAVAILABLE"
+  | "UNKNOWN";
+
+export type CrmErrorCode =
+  | "VALIDATION_ERROR"
+  | "ACCOUNT_NOT_FOUND"
+  | "CONTACT_INVALID"
+  | "CRM_FIELD_REJECTED"
+  | "CRM_UNAVAILABLE"
+  | "CRM_ERROR"
+  | "UNKNOWN";
+
+export interface CrmErrorInfo {
+  code: CrmErrorCode;
+  category: CrmErrorCategory;
+  step: string;
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/sm-crm-fn/_shared/types/dynamics.ts
+++ b/apps/sm-crm-fn/_shared/types/dynamics.ts
@@ -219,10 +219,42 @@ export type CrmErrorCode =
   | "CRM_ERROR"
   | "UNKNOWN";
 
+/**
+ * Codici di errore di validazione a livello di singolo campo del payload.
+ *
+ * - `required`: campo obbligatorio mancante
+ * - `invalid_type`: tipo del valore non corretto
+ * - `invalid_email`: formato email non valido
+ * - `invalid_value`: valore non ammesso (es. fuori da un enum/picklist)
+ */
+export type FieldValidationCode =
+  | "required"
+  | "invalid_type"
+  | "invalid_email"
+  | "invalid_value";
+
+/**
+ * Dettaglio di validazione riferito a un singolo campo del payload di richiesta.
+ *
+ * @property field percorso del campo in notazione a punti (es. `partecipanti.0.email`)
+ * @property code  codice macchina dell'errore di validazione
+ * @property message messaggio descrittivo, leggibile dall'utente
+ */
+export interface FieldValidationError {
+  field: string;
+  code: FieldValidationCode;
+  message: string;
+}
+
 export interface CrmErrorInfo {
   code: CrmErrorCode;
   category: CrmErrorCategory;
   step: string;
+  /**
+   * Elenco degli errori di validazione per singolo campo. Valorizzato solo
+   * quando `code` è `VALIDATION_ERROR`; assente negli altri casi.
+   */
+  fields?: FieldValidationError[];
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/sm-crm-fn/diagnostics/handler.ts
+++ b/apps/sm-crm-fn/diagnostics/handler.ts
@@ -6,6 +6,7 @@ import type {
 import { resolveEnvironment } from "../_shared/utils/mappings";
 import { getConfig } from "../_shared/utils/config";
 import { get, buildUrl } from "../_shared/services/httpClient";
+import { CrmError } from "../_shared/errors/CrmError";
 import { createLogger } from "../_shared/utils/logger";
 import {
   resolveDynamicsEnvironment,
@@ -459,10 +460,15 @@ export async function probeDynamicsHandler(
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
-        const statusMatch = errorMessage.match(/failed: (\d+)/);
-        const statusCode = statusMatch
-          ? parseInt(statusMatch[1], 10)
-          : undefined;
+        // CrmError espone lo status come campo tipizzato; per gli altri errori
+        // si ricade sul parsing del pattern "failed: <status>" nel messaggio.
+        let statusCode: number | undefined;
+        if (error instanceof CrmError) {
+          statusCode = error.status;
+        } else {
+          const statusMatch = errorMessage.match(/failed: (\d+)/);
+          statusCode = statusMatch ? parseInt(statusMatch[1], 10) : undefined;
+        }
         results[candidate] = {
           success: false,
           statusCode,

--- a/apps/sm-crm-fn/docs/API_GUIDE.md
+++ b/apps/sm-crm-fn/docs/API_GUIDE.md
@@ -1079,6 +1079,19 @@ Content-Type: application/json
 
 ### Error Scenarios
 
+#### Oggetto `error` neutro (contratto SMION-800)
+
+In caso di fallimento, la risposta include un oggetto `error` **neutro e stabile**
+che il frontend usa per mostrare un messaggio user-facing. Il dettaglio grezzo di
+Dynamics non è mai incluso nella risposta: resta solo nei log server-side.
+
+```json
+{ "success": false, "error": { "code": "ACCOUNT_NOT_FOUND", "category": "NOT_FOUND", "step": "verifyAccount" } }
+```
+
+Il catalogo completo dei codici e i messaggi italiani suggeriti sono in
+[`FE_ERROR_CODES_GUIDE.md`](./FE_ERROR_CODES_GUIDE.md).
+
 #### Scenario 1: Institution Not Found
 
 **Request**:

--- a/apps/sm-crm-fn/docs/FE_ERROR_CODES_GUIDE.md
+++ b/apps/sm-crm-fn/docs/FE_ERROR_CODES_GUIDE.md
@@ -1,0 +1,47 @@
+# Guida errori CRM per il Frontend (SMION-800)
+
+Quando `POST /meetings` fallisce, la Function restituisce un oggetto `error`
+**neutro e stabile**. Il frontend è responsabile della traduzione in messaggi
+user-facing (italiano). Il dettaglio grezzo di Dynamics NON è mai incluso nella
+risposta: resta solo nei log server-side.
+
+## Forma della risposta di errore
+
+```jsonc
+{
+  "success": false,
+  "message": "Errore durante la creazione dell'appuntamento", // legacy
+  "error": {
+    "code": "ACCOUNT_NOT_FOUND",
+    "category": "NOT_FOUND",
+    "step": "verifyAccount"
+  },
+  "timestamp": "2026-07-09T..."
+}
+```
+
+## Catalogo codici
+
+| `code` | `category` | HTTP | Quando accade | Messaggio IT suggerito |
+|--------|-----------|------|---------------|------------------------|
+| `VALIDATION_ERROR` | `VALIDATION` | 400 | Payload non valido | Alcuni dati inseriti non sono validi. Controlla i campi e riprova. |
+| `ACCOUNT_NOT_FOUND` | `NOT_FOUND` | 500 | Ente non risolto | Ente non trovato nel CRM. Verifica l'ente selezionato. |
+| `CONTACT_INVALID` | `NOT_FOUND` | 500 | Contatto non trovato/creabile | Contatto non valido o non trovato nel CRM. Verifica i partecipanti. |
+| `CRM_FIELD_REJECTED` | `CRM_REJECTED` | 500 | Dynamics rifiuta un campo/valore | Il CRM ha rifiutato uno dei valori inviati. Contatta il supporto. |
+| `CRM_UNAVAILABLE` | `CRM_UNAVAILABLE` | 500 | Timeout / 5xx Dynamics | Il CRM non è al momento raggiungibile. Riprova più tardi. |
+| `CRM_ERROR` | `UNKNOWN` | 500 | Errore CRM non classificato | Errore CRM. Riprova più tardi o contatta il supporto. |
+| `UNKNOWN` | `UNKNOWN` | 500 | Fallback estremo | Errore CRM. Riprova più tardi o contatta il supporto. |
+
+## Come consumarlo lato FE
+
+1. Leggi `data.error?.code`.
+2. Mappa il `code` sul messaggio italiano (vedi `lib/crm-error-messages.ts`).
+3. Per un `code` sconosciuto, usa il fallback generico.
+4. Se `error` è assente (es. risposta legacy), usa `data.message`.
+
+## Retro-compatibilità
+
+- Il campo `message` resta presente. I client che non conoscono `error` continuano
+  a funzionare.
+- Nuovi codici possono essere aggiunti in futuro: il FE deve sempre prevedere il
+  fallback generico per codici non riconosciuti.

--- a/apps/sm-crm-fn/meetings/handler.ts
+++ b/apps/sm-crm-fn/meetings/handler.ts
@@ -39,18 +39,18 @@ export async function createMeetingHandler(
     // Validazione
     const validation = validateOrchestratorRequest(body);
     if (!validation.valid) {
-      const errors = validation.errors;
-      context.warn("Validation errors:", errors);
+      const fields = validation.fields;
+      context.warn("Validation errors:", fields);
       return {
         status: 400,
         jsonBody: {
           success: false,
           message: "Errore di validazione",
-          errors,
           error: {
             code: "VALIDATION_ERROR",
             category: "VALIDATION",
             step: "validation",
+            fields,
           },
           timestamp: new Date().toISOString(),
         },
@@ -209,13 +209,18 @@ export async function dryRunMeetingHandler(
 
     const validation = validateOrchestratorRequest(requestWithDryRun);
     if (!validation.valid) {
-      const errors = validation.errors;
+      const fields = validation.fields;
       return {
         status: 400,
         jsonBody: {
           success: false,
           message: "Errore di validazione",
-          errors,
+          error: {
+            code: "VALIDATION_ERROR",
+            category: "VALIDATION",
+            step: "validation",
+            fields,
+          },
           timestamp: new Date().toISOString(),
         },
       };

--- a/apps/sm-crm-fn/meetings/handler.ts
+++ b/apps/sm-crm-fn/meetings/handler.ts
@@ -47,6 +47,11 @@ export async function createMeetingHandler(
           success: false,
           message: "Errore di validazione",
           errors,
+          error: {
+            code: "VALIDATION_ERROR",
+            category: "VALIDATION",
+            step: "validation",
+          },
           timestamp: new Date().toISOString(),
         },
       };
@@ -76,6 +81,7 @@ export async function createMeetingHandler(
       status,
       jsonBody: {
         ...result,
+        ...(result.success ? {} : { error: result.errorInfo }),
         message: result.success
           ? result.dryRun
             ? "Dry-run completato con successo"
@@ -98,13 +104,16 @@ export async function createMeetingHandler(
       };
     }
 
-    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       status: 500,
       jsonBody: {
         success: false,
         message: "Errore interno del server",
-        error: errorMessage,
+        error: {
+          code: "CRM_ERROR",
+          category: "UNKNOWN",
+          step: "unexpected",
+        },
         timestamp: new Date().toISOString(),
       },
     };

--- a/apps/sm-crm-fn/openapi.yaml
+++ b/apps/sm-crm-fn/openapi.yaml
@@ -987,13 +987,55 @@ components:
         message:
           type: string
           example: "Errore di validazione"
-        errors:
-          type: array
-          items:
-            type: string
+        error:
+          $ref: "#/components/schemas/ValidationErrorInfo"
         timestamp:
           type: string
           format: date-time
+
+    ValidationErrorInfo:
+      type: object
+      description: |
+        Dettaglio strutturato dell'errore di validazione. Il campo `fields`,
+        opzionale, elenca i singoli campi del payload non validi.
+      properties:
+        code:
+          type: string
+          example: "VALIDATION_ERROR"
+        category:
+          type: string
+          example: "VALIDATION"
+        step:
+          type: string
+          example: "validation"
+        fields:
+          type: array
+          description: Elenco degli errori di validazione per singolo campo.
+          items:
+            $ref: "#/components/schemas/FieldValidationError"
+
+    FieldValidationError:
+      type: object
+      required:
+        - field
+        - code
+        - message
+      properties:
+        field:
+          type: string
+          description: Percorso del campo in notazione a punti.
+          example: "partecipanti.0.email"
+        code:
+          type: string
+          enum:
+            - required
+            - invalid_type
+            - invalid_email
+            - invalid_value
+          example: "required"
+        message:
+          type: string
+          example: "subject è obbligatorio"
 
     CreateContactsRequest:
       type: object

--- a/apps/sm-fe-smcr/components/call-management/crm-form.tsx
+++ b/apps/sm-fe-smcr/components/call-management/crm-form.tsx
@@ -116,7 +116,17 @@ export default function CRMForm({ taxCode, institutions }: CRMFormProps) {
     const crmResult = await createMeetingAction(payLoad);
 
     if (!crmResult.success) {
-      toast.error(crmResult.error);
+      const fieldErrors = crmResult.errors;
+      toast.error(crmResult.error, {
+        description:
+          fieldErrors && fieldErrors.length > 0 ? (
+            <ul className="mt-1 list-disc pl-4">
+              {fieldErrors.map((fieldError, index) => (
+                <li key={index}>{fieldError}</li>
+              ))}
+            </ul>
+          ) : undefined,
+      });
       return;
     }
 
@@ -615,7 +625,6 @@ export default function CRMForm({ taxCode, institutions }: CRMFormProps) {
                 )}
               />
             </div>
-
           </FieldGroup>
         </FieldSet>
 

--- a/apps/sm-fe-smcr/lib/__tests__/crm-error-messages.test.ts
+++ b/apps/sm-fe-smcr/lib/__tests__/crm-error-messages.test.ts
@@ -1,0 +1,21 @@
+import { getCrmErrorMessage } from "../crm-error-messages";
+
+describe("getCrmErrorMessage", () => {
+  it("returns the Italian message for a known code", () => {
+    expect(getCrmErrorMessage("ACCOUNT_NOT_FOUND")).toBe(
+      "Ente non trovato nel CRM. Verifica l'ente selezionato.",
+    );
+  });
+
+  it("returns the generic fallback for an unknown code", () => {
+    expect(getCrmErrorMessage("SOMETHING_NEW")).toBe(
+      "Errore CRM. Riprova più tardi o contatta il supporto.",
+    );
+  });
+
+  it("returns the generic fallback when code is undefined", () => {
+    expect(getCrmErrorMessage(undefined)).toBe(
+      "Errore CRM. Riprova più tardi o contatta il supporto.",
+    );
+  });
+});

--- a/apps/sm-fe-smcr/lib/actions/call-management.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/call-management.action.ts
@@ -288,12 +288,52 @@ export type CreateMeetingInput = {
 
 export type CreateMeetingResult =
   | { success: true; activityId?: string; message?: string }
-  | { success: false; error: string };
+  | { success: false; error: string; errors?: string[] };
 
 type CreateMeetingResponse = {
   activityId?: string;
   message?: string;
   error?: unknown;
+};
+
+/**
+ * Estrae dagli errori strutturati della function CRM (`error.fields[]`) un
+ * elenco di messaggi leggibili, uno per singolo campo non valido.
+ *
+ * Ogni voce è resa come `"field: message"` quando il campo è disponibile,
+ * altrimenti come solo `message`, così da poter mostrare il dettaglio campo
+ * per campo all'utente.
+ *
+ * @param error valore grezzo del campo `error` del payload di risposta
+ * @returns elenco di messaggi per-campo, oppure `undefined` se non presente
+ */
+const extractFieldValidationErrors = (error: unknown): string[] | undefined => {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  const fields = (error as { fields?: unknown }).fields;
+  if (!Array.isArray(fields)) {
+    return undefined;
+  }
+
+  const messages = fields
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return undefined;
+      }
+      const record = entry as { field?: unknown; message?: unknown };
+      const message =
+        typeof record.message === "string" ? record.message : undefined;
+      const field = typeof record.field === "string" ? record.field : undefined;
+      if (!message) {
+        return undefined;
+      }
+      return field ? `${field}: ${message}` : message;
+    })
+    .filter((entry): entry is string => Boolean(entry && entry.trim()));
+
+  return messages.length > 0 ? messages : undefined;
 };
 
 const truncateLogValue = (value: string, maxLength = 2000) =>
@@ -465,9 +505,12 @@ export async function createMeetingAction(
           ? (data.error as { code: string }).code
           : undefined;
 
+      const validationErrors = extractFieldValidationErrors(data.error);
+
       return {
         success: false,
         error: neutralCode ? getCrmErrorMessage(neutralCode) : message,
+        ...(validationErrors ? { errors: validationErrors } : {}),
       };
     }
 

--- a/apps/sm-fe-smcr/lib/actions/call-management.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/call-management.action.ts
@@ -294,7 +294,6 @@ type CreateMeetingResponse = {
   activityId?: string;
   message?: string;
   error?: unknown;
-  errorCode?: string;
 };
 
 const truncateLogValue = (value: string, maxLength = 2000) =>

--- a/apps/sm-fe-smcr/lib/actions/call-management.action.ts
+++ b/apps/sm-fe-smcr/lib/actions/call-management.action.ts
@@ -6,6 +6,7 @@ import { it } from "date-fns/locale";
 import z from "zod";
 import { PRODUCT_MAP } from "../types/product";
 import logger from "@/lib/logger/logger.server";
+import { getCrmErrorMessage } from "@/lib/crm-error-messages";
 import { serverEnv } from "@/config/env";
 import { tipologiaReferenteValues } from "@/components/call-management/crm-form-schema";
 
@@ -293,6 +294,7 @@ type CreateMeetingResponse = {
   activityId?: string;
   message?: string;
   error?: unknown;
+  errorCode?: string;
 };
 
 const truncateLogValue = (value: string, maxLength = 2000) =>
@@ -455,7 +457,19 @@ export async function createMeetingAction(
         },
         "createMeetingAction failed",
       );
-      return { success: false, error: message };
+      const neutralCode =
+        data.error &&
+        typeof data.error === "object" &&
+        data.error !== null &&
+        "code" in data.error &&
+        typeof (data.error as { code?: unknown }).code === "string"
+          ? (data.error as { code: string }).code
+          : undefined;
+
+      return {
+        success: false,
+        error: neutralCode ? getCrmErrorMessage(neutralCode) : message,
+      };
     }
 
     logger.info(

--- a/apps/sm-fe-smcr/lib/crm-error-messages.ts
+++ b/apps/sm-fe-smcr/lib/crm-error-messages.ts
@@ -1,0 +1,32 @@
+const GENERIC_CRM_ERROR =
+  "Errore CRM. Riprova più tardi o contatta il supporto.";
+
+/**
+ * Mappa i codici d'errore neutri emessi dalla Azure Function (contratto
+ * SMION-800) sui messaggi mostrati all'utente in italiano. Unico punto
+ * dell'applicazione in cui i codici CRM diventano testo user-facing.
+ */
+const CRM_ERROR_MESSAGES: Record<string, string> = {
+  VALIDATION_ERROR:
+    "Alcuni dati inseriti non sono validi. Controlla i campi e riprova.",
+  ACCOUNT_NOT_FOUND: "Ente non trovato nel CRM. Verifica l'ente selezionato.",
+  CONTACT_INVALID:
+    "Contatto non valido o non trovato nel CRM. Verifica i partecipanti.",
+  CRM_FIELD_REJECTED:
+    "Il CRM ha rifiutato uno dei valori inviati. Contatta il supporto.",
+  CRM_UNAVAILABLE:
+    "Il CRM non è al momento raggiungibile. Riprova più tardi.",
+  CRM_ERROR: GENERIC_CRM_ERROR,
+  UNKNOWN: GENERIC_CRM_ERROR,
+};
+
+/**
+ * Restituisce il messaggio italiano per un codice d'errore CRM, con
+ * fallback generico per codici sconosciuti o assenti.
+ */
+export function getCrmErrorMessage(code?: string): string {
+  if (code && Object.prototype.hasOwnProperty.call(CRM_ERROR_MESSAGES, code)) {
+    return CRM_ERROR_MESSAGES[code]!;
+  }
+  return GENERIC_CRM_ERROR;
+}

--- a/apps/sm-fe-smcr/lib/crm-error-messages.ts
+++ b/apps/sm-fe-smcr/lib/crm-error-messages.ts
@@ -14,8 +14,7 @@ const CRM_ERROR_MESSAGES: Record<string, string> = {
     "Contatto non valido o non trovato nel CRM. Verifica i partecipanti.",
   CRM_FIELD_REJECTED:
     "Il CRM ha rifiutato uno dei valori inviati. Contatta il supporto.",
-  CRM_UNAVAILABLE:
-    "Il CRM non è al momento raggiungibile. Riprova più tardi.",
+  CRM_UNAVAILABLE: "Il CRM non è al momento raggiungibile. Riprova più tardi.",
   CRM_ERROR: GENERIC_CRM_ERROR,
   UNKNOWN: GENERIC_CRM_ERROR,
 };

--- a/docs/superpowers/plans/2026-07-09-smion-800-crm-error-propagation.md
+++ b/docs/superpowers/plans/2026-07-09-smion-800-crm-error-propagation.md
@@ -1,0 +1,833 @@
+# SMION-800 — CRM Error Propagation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Propagate a stable, neutral CRM error contract (`code` + `category` + `step`) from the Azure Function to the frontend so users see a comprehensible Italian message, without coupling the Function to the frontend's language/UX and without exposing CRM schema.
+
+**Architecture:** Approach A — a typed `CrmError` carries raw Dynamics failure detail; a pure `crmErrorMapper` classifies it into neutral codes; the orchestrator attaches the failing `step`; the `meetings` handler emits `error: { code, category, step }` (raw detail stays server-side only). The frontend owns the `code → Italian message` mapping.
+
+**Tech Stack:** TypeScript, Azure Functions v4 (Node 22), Jest (both apps), Next.js 15 server actions.
+
+**Design spec:** `docs/superpowers/specs/2026-07-09-smion-800-crm-error-propagation-design.md`
+
+---
+
+## File Structure
+
+**Function (`apps/sm-crm-fn`):**
+- Create `_shared/errors/CrmError.ts` — typed error (`status`, `odataCode`, `rawDetail`, `step`).
+- Create `_shared/services/crmErrorMapper.ts` — pure `mapCrmError()` → `CrmErrorInfo`.
+- Create `__tests__/crmErrorMapper.test.ts` — one test per branch.
+- Modify `_shared/types/dynamics.ts` — add `CrmErrorInfo` + `errorInfo?` on `CreateMeetingOrchestratorResponse`.
+- Modify `_shared/services/httpClient.ts` — throw `CrmError` in the `!response.ok` branch.
+- Modify `_shared/services/orchestrator.ts` — compute + pass `errorInfo` at each error site and in `buildErrorResponse`.
+- Modify `meetings/handler.ts` — emit `error: { code, category, step }`; validation → `VALIDATION_ERROR`.
+
+**Frontend (`apps/sm-fe-smcr`):**
+- Create `lib/crm-error-messages.ts` — `code → IT message` dictionary + `getCrmErrorMessage()`.
+- Create `lib/__tests__/crm-error-messages.test.ts` — known code + fallback.
+- Modify `lib/actions/call-management.action.ts` — read `data.error.code`, return mapped message.
+
+**Docs:**
+- Create `apps/sm-crm-fn/docs/FE_ERROR_CODES_GUIDE.md`.
+- Modify `apps/sm-crm-fn/docs/API_GUIDE.md` — document the `error` object.
+
+---
+
+## Task 1: Add `CrmError` class and `CrmErrorInfo` type
+
+**Files:**
+- Create: `apps/sm-crm-fn/_shared/errors/CrmError.ts`
+- Modify: `apps/sm-crm-fn/_shared/types/dynamics.ts` (after `CreateMeetingOrchestratorResponse`, ~line 203)
+
+- [ ] **Step 1: Create the `CrmError` class**
+
+Create `apps/sm-crm-fn/_shared/errors/CrmError.ts`:
+
+```typescript
+/**
+ * Errore tipizzato per fallimenti provenienti da Dynamics 365.
+ *
+ * Trasporta il contesto tecnico grezzo (status HTTP, codice OData, testo grezzo)
+ * verso i layer superiori SENZA esporlo nella risposta HTTP: il `rawDetail` è
+ * destinato esclusivamente ai log server-side (App Insights / DiagnosticSession).
+ */
+export class CrmError extends Error {
+  readonly status: number;
+  readonly odataCode?: string;
+  readonly rawDetail?: string;
+  step?: string;
+
+  constructor(params: {
+    status: number;
+    odataCode?: string;
+    rawDetail?: string;
+    step?: string;
+    message?: string;
+  }) {
+    super(params.message ?? `CRM request failed (status ${params.status})`);
+    this.name = "CrmError";
+    this.status = params.status;
+    this.odataCode = params.odataCode;
+    this.rawDetail = params.rawDetail;
+    this.step = params.step;
+  }
+}
+```
+
+- [ ] **Step 2: Add `CrmErrorInfo` type and `errorInfo` field**
+
+In `apps/sm-crm-fn/_shared/types/dynamics.ts`, immediately after the closing `}` of `CreateMeetingOrchestratorResponse` (currently ~line 203), add:
+
+```typescript
+export type CrmErrorCategory =
+  | "VALIDATION"
+  | "NOT_FOUND"
+  | "CRM_REJECTED"
+  | "CRM_UNAVAILABLE"
+  | "UNKNOWN";
+
+export type CrmErrorCode =
+  | "VALIDATION_ERROR"
+  | "ACCOUNT_NOT_FOUND"
+  | "CONTACT_INVALID"
+  | "CRM_FIELD_REJECTED"
+  | "CRM_UNAVAILABLE"
+  | "CRM_ERROR"
+  | "UNKNOWN";
+
+export interface CrmErrorInfo {
+  code: CrmErrorCode;
+  category: CrmErrorCategory;
+  step: string;
+}
+```
+
+Then add `errorInfo` as an optional field inside `CreateMeetingOrchestratorResponse` (after `warnings: string[];`, before `timestamp: string;`):
+
+```typescript
+  errorInfo?: CrmErrorInfo;
+```
+
+- [ ] **Step 3: Build to verify types compile**
+
+Run: `cd apps/sm-crm-fn && yarn build`
+Expected: build succeeds (tsc exits 0), no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/sm-crm-fn/_shared/errors/CrmError.ts apps/sm-crm-fn/_shared/types/dynamics.ts
+git commit -m "feat(SMION-800): add CrmError class and CrmErrorInfo type
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 2: Add `crmErrorMapper` (pure classification)
+
+**Files:**
+- Create: `apps/sm-crm-fn/_shared/services/crmErrorMapper.ts`
+- Test: `apps/sm-crm-fn/__tests__/crmErrorMapper.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/sm-crm-fn/__tests__/crmErrorMapper.test.ts`:
+
+```typescript
+import { mapCrmError } from "../_shared/services/crmErrorMapper";
+import { CrmError } from "../_shared/errors/CrmError";
+
+describe("mapCrmError", () => {
+  it("classifies verifyAccount failures as ACCOUNT_NOT_FOUND", () => {
+    expect(mapCrmError({ step: "verifyAccount" })).toEqual({
+      code: "ACCOUNT_NOT_FOUND",
+      category: "NOT_FOUND",
+      step: "verifyAccount",
+    });
+  });
+
+  it("classifies verifyOrCreateContacts failures as CONTACT_INVALID", () => {
+    expect(mapCrmError({ step: "verifyOrCreateContacts" })).toEqual({
+      code: "CONTACT_INVALID",
+      category: "NOT_FOUND",
+      step: "verifyOrCreateContacts",
+    });
+  });
+
+  it("classifies a Dynamics field-rejection OData code as CRM_FIELD_REJECTED", () => {
+    const error = new CrmError({
+      status: 400,
+      odataCode: "0x80040265",
+      rawDetail: "The entity field xyz is invalid",
+      step: "createAppointment",
+    });
+    expect(mapCrmError({ step: "createAppointment", error })).toEqual({
+      code: "CRM_FIELD_REJECTED",
+      category: "CRM_REJECTED",
+      step: "createAppointment",
+    });
+  });
+
+  it("classifies Dynamics 5xx as CRM_UNAVAILABLE", () => {
+    const error = new CrmError({ status: 503, step: "createAppointment" });
+    expect(mapCrmError({ step: "createAppointment", error })).toEqual({
+      code: "CRM_UNAVAILABLE",
+      category: "CRM_UNAVAILABLE",
+      step: "createAppointment",
+    });
+  });
+
+  it("falls back to CRM_ERROR for an unclassified createAppointment failure", () => {
+    const error = new CrmError({ status: 400, step: "createAppointment" });
+    expect(mapCrmError({ step: "createAppointment", error })).toEqual({
+      code: "CRM_ERROR",
+      category: "UNKNOWN",
+      step: "createAppointment",
+    });
+  });
+
+  it("falls back to UNKNOWN for an unrecognised step without error", () => {
+    expect(mapCrmError({ step: "somethingElse" })).toEqual({
+      code: "UNKNOWN",
+      category: "UNKNOWN",
+      step: "somethingElse",
+    });
+  });
+
+  it("never leaks rawDetail into the mapped output", () => {
+    const error = new CrmError({
+      status: 400,
+      odataCode: "0x80040265",
+      rawDetail: "SECRET schema attribute pgp_internal",
+      step: "createAppointment",
+    });
+    const result = mapCrmError({ step: "createAppointment", error });
+    expect(JSON.stringify(result)).not.toContain("SECRET");
+    expect(JSON.stringify(result)).not.toContain("rawDetail");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/sm-crm-fn && yarn jest crmErrorMapper -c`
+Expected: FAIL — cannot find module `../_shared/services/crmErrorMapper`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/sm-crm-fn/_shared/services/crmErrorMapper.ts`:
+
+```typescript
+import { CrmError } from "../errors/CrmError";
+import type { CrmErrorInfo } from "../types/dynamics";
+
+/**
+ * Codici OData Dynamics che indicano un valore/campo rifiutato dal CRM
+ * (schema, optionset, campo inesistente o non valido).
+ */
+const FIELD_REJECTION_ODATA_CODES = new Set<string>([
+  "0x80040265",
+  "0x80040217",
+  "0x8004431a",
+]);
+
+/**
+ * Classifica un fallimento CRM in un codice d'errore neutro e stabile.
+ *
+ * Funzione pura: non conosce HTTP né testi user-facing. Il `rawDetail`
+ * dell'eventuale CrmError NON viene mai incluso nell'output.
+ *
+ * @param params.step - Step del flusso in cui è avvenuto l'errore.
+ * @param params.error - Errore risalito (tipicamente un CrmError), opzionale.
+ * @returns Informazione d'errore neutra { code, category, step }.
+ */
+export function mapCrmError(params: {
+  step: string;
+  error?: unknown;
+}): CrmErrorInfo {
+  const { step, error } = params;
+
+  if (error instanceof CrmError) {
+    if (error.status >= 500 || error.status === 0) {
+      return { code: "CRM_UNAVAILABLE", category: "CRM_UNAVAILABLE", step };
+    }
+    if (error.odataCode && FIELD_REJECTION_ODATA_CODES.has(error.odataCode)) {
+      return { code: "CRM_FIELD_REJECTED", category: "CRM_REJECTED", step };
+    }
+  }
+
+  switch (step) {
+    case "verifyAccount":
+      return { code: "ACCOUNT_NOT_FOUND", category: "NOT_FOUND", step };
+    case "verifyOrCreateContacts":
+      return { code: "CONTACT_INVALID", category: "NOT_FOUND", step };
+    case "createAppointment":
+      return { code: "CRM_ERROR", category: "UNKNOWN", step };
+    default:
+      return { code: "UNKNOWN", category: "UNKNOWN", step };
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/sm-crm-fn && yarn jest crmErrorMapper -c`
+Expected: PASS — 7 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/sm-crm-fn/_shared/services/crmErrorMapper.ts apps/sm-crm-fn/__tests__/crmErrorMapper.test.ts
+git commit -m "feat(SMION-800): add crmErrorMapper pure classifier with tests
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 3: `httpClient.post` throws `CrmError`
+
+**Files:**
+- Modify: `apps/sm-crm-fn/_shared/services/httpClient.ts` (import at top ~line 9; `!response.ok` branch ~line 278-287)
+
+- [ ] **Step 1: Add the import**
+
+In `apps/sm-crm-fn/_shared/services/httpClient.ts`, add after the existing type import (line 8 `import type { DynamicsList } ...`):
+
+```typescript
+import { CrmError } from "../errors/CrmError";
+```
+
+- [ ] **Step 2: Replace the raw throw in the `!response.ok` branch**
+
+In `post()`, replace this block (currently ~lines 278-287):
+
+```typescript
+    if (!response.ok) {
+      const errorBody = await response.text();
+      logger.error(`POST request failed`, new Error(errorBody), {
+        url,
+        statusCode: response.status,
+        duration,
+        method: "POST",
+      });
+      throw new Error(`POST ${url} failed: ${response.status} - ${errorBody}`);
+    }
+```
+
+with:
+
+```typescript
+    if (!response.ok) {
+      const errorBody = await response.text();
+      let odataCode: string | undefined;
+      try {
+        const parsed = JSON.parse(errorBody) as {
+          error?: { code?: string };
+        };
+        odataCode = parsed.error?.code;
+      } catch {
+        odataCode = undefined;
+      }
+      // rawDetail resta SOLO nei log server-side, mai nella risposta HTTP.
+      logger.error(`POST request failed`, new Error(errorBody), {
+        url,
+        statusCode: response.status,
+        duration,
+        method: "POST",
+      });
+      throw new CrmError({
+        status: response.status,
+        odataCode,
+        rawDetail: errorBody,
+        message: `POST ${url} failed: ${response.status}`,
+      });
+    }
+```
+
+- [ ] **Step 3: Verify the existing `0x80040265` fallback still triggers**
+
+The fallback in `appointments.ts` (~line 437) checks `errorMessage.includes("0x80040265")`. Since `CrmError.message` no longer contains the OData code, update that check to use the typed field.
+
+In `apps/sm-crm-fn/_shared/services/appointments.ts`, view lines 430-450 and replace the guard:
+
+```typescript
+    if (!errorMessage.includes("0x80040265")) {
+```
+
+with a `CrmError`-aware check. First add the import near the top of `appointments.ts` (with the other imports):
+
+```typescript
+import { CrmError } from "../errors/CrmError";
+```
+
+Then replace the guard block. Locate the `catch (error)` that wraps the appointment creation retry and change the condition to:
+
+```typescript
+    const odataCode = error instanceof CrmError ? error.odataCode : undefined;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    if (odataCode !== "0x80040265" && !errorMessage.includes("0x80040265")) {
+```
+
+(Keep the rest of the fallback body unchanged. The `errorMessage.includes` clause preserves behavior for any non-CrmError path.)
+
+- [ ] **Step 4: Build and run the full Function test suite**
+
+Run: `cd apps/sm-crm-fn && yarn build && yarn jest -c`
+Expected: build succeeds; all tests pass (config, appointmentPersistence, crmErrorMapper).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/sm-crm-fn/_shared/services/httpClient.ts apps/sm-crm-fn/_shared/services/appointments.ts
+git commit -m "feat(SMION-800): throw typed CrmError from httpClient.post
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 4: Orchestrator propagates `errorInfo`
+
+**Files:**
+- Modify: `apps/sm-crm-fn/_shared/services/orchestrator.ts` (imports; `buildErrorResponse` ~line 664; error sites ~lines 166, 196, 378-397, 417+)
+
+- [ ] **Step 1: Add imports**
+
+At the top of `apps/sm-crm-fn/_shared/services/orchestrator.ts`, add:
+
+```typescript
+import { mapCrmError } from "./crmErrorMapper";
+import type { CrmErrorInfo } from "../types/dynamics";
+```
+
+- [ ] **Step 2: Extend `buildErrorResponse` to accept and emit `errorInfo`**
+
+Change the signature of `buildErrorResponse` (~line 664) to add a parameter:
+
+```typescript
+async function buildErrorResponse(
+  steps: OrchestratorStepResult[],
+  warnings: string[],
+  dryRun: boolean,
+  errorMessage: string,
+  errorInfo: CrmErrorInfo,
+  diagnosticSession?: DiagnosticSession,
+): Promise<CreateMeetingOrchestratorResponse> {
+```
+
+Inside, add `errorInfo` to the constructed `response` object (after `warnings,`):
+
+```typescript
+  const response: CreateMeetingOrchestratorResponse = {
+    success: false,
+    dryRun,
+    steps,
+    warnings,
+    errorInfo,
+    timestamp: new Date().toISOString(),
+  };
+```
+
+- [ ] **Step 3: Pass `errorInfo` at the verifyAccount exception site (~line 166)**
+
+Replace the `return buildErrorResponse(...)` call inside the `catch (error)` of STEP 1 (currently ~line 166-172) with:
+
+```typescript
+      return buildErrorResponse(
+        steps,
+        warnings,
+        dryRun,
+        `Errore durante verifica ente: ${msg}`,
+        mapCrmError({ step: "verifyAccount", error }),
+        diagnosticSession,
+      );
+```
+
+- [ ] **Step 4: Pass `errorInfo` at the verifyAccount not-found site (~line 196)**
+
+Replace the `return buildErrorResponse(...)` call in the `if (!accountResult.found ...)` block (currently ~line 196-202) with:
+
+```typescript
+      return buildErrorResponse(
+        steps,
+        warnings,
+        dryRun,
+        accountResult.error ?? "Ente non trovato",
+        mapCrmError({ step: "verifyAccount" }),
+        diagnosticSession,
+      );
+```
+
+- [ ] **Step 5: Pass `errorInfo` at the contacts and appointment error sites**
+
+For every remaining `return buildErrorResponse(...)` in this file, add the `mapCrmError({...})` argument before `diagnosticSession`, using the step matching that block:
+- Contacts block(s) (~line 378-397 and the surrounding `catch (error)` ~line 417): use `mapCrmError({ step: "verifyOrCreateContacts", error })` (include `error` only where an `error` variable exists in scope; otherwise omit it).
+- Appointment creation block: use `mapCrmError({ step: "createAppointment", error })`.
+
+View each `return buildErrorResponse(` occurrence (`grep -n "buildErrorResponse" apps/sm-crm-fn/_shared/services/orchestrator.ts`) and insert the correct argument so every call passes 6 arguments.
+
+- [ ] **Step 6: Build to verify all call sites are updated**
+
+Run: `cd apps/sm-crm-fn && yarn build`
+Expected: build succeeds. If tsc reports "Expected 6 arguments, but got 5" at any `buildErrorResponse` call, fix that call site.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/sm-crm-fn/_shared/services/orchestrator.ts
+git commit -m "feat(SMION-800): propagate errorInfo from orchestrator error sites
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 5: `meetings/handler.ts` emits the `error` object
+
+**Files:**
+- Modify: `apps/sm-crm-fn/meetings/handler.ts` (validation branch ~line 44-52; result branch ~line 75-85; catch ~line 100-110)
+
+- [ ] **Step 1: Emit `error` on the validation branch**
+
+In `createMeetingHandler`, replace the validation-failure return (currently ~line 44-52):
+
+```typescript
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: "Errore di validazione",
+          errors,
+          timestamp: new Date().toISOString(),
+        },
+      };
+```
+
+with:
+
+```typescript
+      return {
+        status: 400,
+        jsonBody: {
+          success: false,
+          message: "Errore di validazione",
+          errors,
+          error: {
+            code: "VALIDATION_ERROR",
+            category: "VALIDATION",
+            step: "validation",
+          },
+          timestamp: new Date().toISOString(),
+        },
+      };
+```
+
+- [ ] **Step 2: Emit `error` on the orchestrator-failure branch**
+
+Replace the main result return (currently ~line 75-85) with a version that includes `errorInfo` when the orchestrator failed:
+
+```typescript
+    return {
+      status,
+      jsonBody: {
+        ...result,
+        ...(result.success ? {} : { error: result.errorInfo }),
+        message: result.success
+          ? result.dryRun
+            ? "Dry-run completato con successo"
+            : "Appuntamento creato con successo"
+          : "Errore durante la creazione dell'appuntamento",
+      },
+    };
+```
+
+(`...result` already includes `errorInfo`; the explicit `error` field mirrors it under the contract name `error` for the frontend. Raw Dynamics detail is never part of `result`, so nothing sensitive is emitted.)
+
+- [ ] **Step 3: Emit `error` on the unexpected-catch branch**
+
+Replace the final catch return (currently ~line 102-110) with:
+
+```typescript
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      status: 500,
+      jsonBody: {
+        success: false,
+        message: "Errore interno del server",
+        error: {
+          code: "CRM_ERROR",
+          category: "UNKNOWN",
+          step: "unexpected",
+        },
+        timestamp: new Date().toISOString(),
+      },
+    };
+```
+
+(Note: `errorMessage` is still logged via `context.error("Unexpected error:", error)` above; it must NOT be placed in `jsonBody`.)
+
+- [ ] **Step 4: Build and run the Function test suite**
+
+Run: `cd apps/sm-crm-fn && yarn build && yarn jest -c`
+Expected: build succeeds; all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/sm-crm-fn/meetings/handler.ts
+git commit -m "feat(SMION-800): emit neutral error object from meetings handler
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 6: Frontend `code → Italian message` mapping
+
+**Files:**
+- Create: `apps/sm-fe-smcr/lib/crm-error-messages.ts`
+- Test: `apps/sm-fe-smcr/lib/__tests__/crm-error-messages.test.ts`
+- Modify: `apps/sm-fe-smcr/lib/actions/call-management.action.ts` (type ~line 292; failure return ~line 458)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/sm-fe-smcr/lib/__tests__/crm-error-messages.test.ts`:
+
+```typescript
+import { getCrmErrorMessage } from "../crm-error-messages";
+
+describe("getCrmErrorMessage", () => {
+  it("returns the Italian message for a known code", () => {
+    expect(getCrmErrorMessage("ACCOUNT_NOT_FOUND")).toBe(
+      "Ente non trovato nel CRM. Verifica l'ente selezionato.",
+    );
+  });
+
+  it("returns the generic fallback for an unknown code", () => {
+    expect(getCrmErrorMessage("SOMETHING_NEW")).toBe(
+      "Errore CRM. Riprova più tardi o contatta il supporto.",
+    );
+  });
+
+  it("returns the generic fallback when code is undefined", () => {
+    expect(getCrmErrorMessage(undefined)).toBe(
+      "Errore CRM. Riprova più tardi o contatta il supporto.",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/sm-fe-smcr && yarn jest crm-error-messages`
+Expected: FAIL — cannot find module `../crm-error-messages`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/sm-fe-smcr/lib/crm-error-messages.ts`:
+
+```typescript
+const GENERIC_CRM_ERROR =
+  "Errore CRM. Riprova più tardi o contatta il supporto.";
+
+/**
+ * Mappa i codici d'errore neutri emessi dalla Azure Function (contratto
+ * SMION-800) sui messaggi mostrati all'utente in italiano. Unico punto
+ * dell'applicazione in cui i codici CRM diventano testo user-facing.
+ */
+const CRM_ERROR_MESSAGES: Record<string, string> = {
+  VALIDATION_ERROR:
+    "Alcuni dati inseriti non sono validi. Controlla i campi e riprova.",
+  ACCOUNT_NOT_FOUND: "Ente non trovato nel CRM. Verifica l'ente selezionato.",
+  CONTACT_INVALID:
+    "Contatto non valido o non trovato nel CRM. Verifica i partecipanti.",
+  CRM_FIELD_REJECTED:
+    "Il CRM ha rifiutato uno dei valori inviati. Contatta il supporto.",
+  CRM_UNAVAILABLE:
+    "Il CRM non è al momento raggiungibile. Riprova più tardi.",
+  CRM_ERROR: GENERIC_CRM_ERROR,
+  UNKNOWN: GENERIC_CRM_ERROR,
+};
+
+/**
+ * Restituisce il messaggio italiano per un codice d'errore CRM, con
+ * fallback generico per codici sconosciuti o assenti.
+ */
+export function getCrmErrorMessage(code?: string): string {
+  if (code && code in CRM_ERROR_MESSAGES) {
+    return CRM_ERROR_MESSAGES[code];
+  }
+  return GENERIC_CRM_ERROR;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/sm-fe-smcr && yarn jest crm-error-messages`
+Expected: PASS — 3 tests green.
+
+- [ ] **Step 5: Wire the action to use the code**
+
+In `apps/sm-fe-smcr/lib/actions/call-management.action.ts`:
+
+(a) Add the import near the top with the other `lib` imports:
+
+```typescript
+import { getCrmErrorMessage } from "@/lib/crm-error-messages";
+```
+
+(b) Extend the `CreateMeetingResponse` type (~line 292) to include the neutral error object:
+
+```typescript
+type CreateMeetingResponse = {
+  activityId?: string;
+  message?: string;
+  error?: unknown;
+  errorCode?: string;
+};
+```
+
+Note: the Function sends `error: { code, category, step }`. Extract the code defensively.
+
+(c) In the `if (!res.ok)` block, after computing the existing `message` variable and before `logger.error(...)` (currently ~line 429-458), compute the neutral code and prefer the mapped message. Replace the `return { success: false, error: message };` (line ~458) with:
+
+```typescript
+      const neutralCode =
+        data.error &&
+        typeof data.error === "object" &&
+        data.error !== null &&
+        "code" in data.error &&
+        typeof (data.error as { code?: unknown }).code === "string"
+          ? (data.error as { code: string }).code
+          : undefined;
+
+      return {
+        success: false,
+        error: neutralCode ? getCrmErrorMessage(neutralCode) : message,
+      };
+```
+
+(This preserves the legacy `message` fallback when no neutral `code` is present — no regression.)
+
+- [ ] **Step 6: Run FE tests and typecheck**
+
+Run: `cd apps/sm-fe-smcr && yarn jest crm-error-messages && yarn build`
+Expected: tests pass; Next.js build/typecheck succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/sm-fe-smcr/lib/crm-error-messages.ts apps/sm-fe-smcr/lib/__tests__/crm-error-messages.test.ts apps/sm-fe-smcr/lib/actions/call-management.action.ts
+git commit -m "feat(SMION-800): map neutral CRM error codes to Italian messages on FE
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 7: Documentation — FE error-codes guide
+
+**Files:**
+- Create: `apps/sm-crm-fn/docs/FE_ERROR_CODES_GUIDE.md`
+- Modify: `apps/sm-crm-fn/docs/API_GUIDE.md` (add the `error` object to the `POST /meetings` error response section)
+
+- [ ] **Step 1: Create the FE guide**
+
+Create `apps/sm-crm-fn/docs/FE_ERROR_CODES_GUIDE.md`:
+
+````markdown
+# Guida errori CRM per il Frontend (SMION-800)
+
+Quando `POST /meetings` fallisce, la Function restituisce un oggetto `error`
+**neutro e stabile**. Il frontend è responsabile della traduzione in messaggi
+user-facing (italiano). Il dettaglio grezzo di Dynamics NON è mai incluso nella
+risposta: resta solo nei log server-side.
+
+## Forma della risposta di errore
+
+```jsonc
+{
+  "success": false,
+  "message": "Errore durante la creazione dell'appuntamento", // legacy
+  "error": {
+    "code": "ACCOUNT_NOT_FOUND",
+    "category": "NOT_FOUND",
+    "step": "verifyAccount"
+  },
+  "timestamp": "2026-07-09T..."
+}
+```
+
+## Catalogo codici
+
+| `code` | `category` | HTTP | Quando accade | Messaggio IT suggerito |
+|--------|-----------|------|---------------|------------------------|
+| `VALIDATION_ERROR` | `VALIDATION` | 400 | Payload non valido | Alcuni dati inseriti non sono validi. Controlla i campi e riprova. |
+| `ACCOUNT_NOT_FOUND` | `NOT_FOUND` | 500 | Ente non risolto | Ente non trovato nel CRM. Verifica l'ente selezionato. |
+| `CONTACT_INVALID` | `NOT_FOUND` | 500 | Contatto non trovato/creabile | Contatto non valido o non trovato nel CRM. Verifica i partecipanti. |
+| `CRM_FIELD_REJECTED` | `CRM_REJECTED` | 500 | Dynamics rifiuta un campo/valore | Il CRM ha rifiutato uno dei valori inviati. Contatta il supporto. |
+| `CRM_UNAVAILABLE` | `CRM_UNAVAILABLE` | 500 | Timeout / 5xx Dynamics | Il CRM non è al momento raggiungibile. Riprova più tardi. |
+| `CRM_ERROR` | `UNKNOWN` | 500 | Errore CRM non classificato | Errore CRM. Riprova più tardi o contatta il supporto. |
+| `UNKNOWN` | `UNKNOWN` | 500 | Fallback estremo | Errore CRM. Riprova più tardi o contatta il supporto. |
+
+## Come consumarlo lato FE
+
+1. Leggi `data.error?.code`.
+2. Mappa il `code` sul messaggio italiano (vedi `lib/crm-error-messages.ts`).
+3. Per un `code` sconosciuto, usa il fallback generico.
+4. Se `error` è assente (es. risposta legacy), usa `data.message`.
+
+## Retro-compatibilità
+
+- Il campo `message` resta presente. I client che non conoscono `error` continuano
+  a funzionare.
+- Nuovi codici possono essere aggiunti in futuro: il FE deve sempre prevedere il
+  fallback generico per codici non riconosciuti.
+````
+
+- [ ] **Step 2: Update `API_GUIDE.md`**
+
+Open `apps/sm-crm-fn/docs/API_GUIDE.md`, find the `POST /meetings` error-response documentation, and add a short subsection describing the `error: { code, category, step }` object, linking to `FE_ERROR_CODES_GUIDE.md`. If no error-response section exists, add one under the `POST /meetings` heading:
+
+```markdown
+### Risposta di errore
+
+In caso di fallimento, la risposta include un oggetto `error` neutro:
+
+```json
+{ "success": false, "error": { "code": "ACCOUNT_NOT_FOUND", "category": "NOT_FOUND", "step": "verifyAccount" } }
+```
+
+Il catalogo completo dei codici è in [`FE_ERROR_CODES_GUIDE.md`](./FE_ERROR_CODES_GUIDE.md).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/sm-crm-fn/docs/FE_ERROR_CODES_GUIDE.md apps/sm-crm-fn/docs/API_GUIDE.md
+git commit -m "docs(SMION-800): add FE error-codes guide and update API guide
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Function CI parity**
+
+Run: `cd /Users/lorenzo.franceschini/dev/pagopa/plsm-service-management && yarn turbo lint --filter=sm-crm-fn && yarn turbo test --filter=sm-crm-fn && yarn turbo build --filter=sm-crm-fn`
+Expected: all green.
+
+- [ ] **Frontend build + targeted tests**
+
+Run: `yarn turbo test --filter=sm-fe-smcr && yarn turbo build --filter=sm-fe-smcr`
+Expected: tests pass, build succeeds.
+
+- [ ] **Prettier**
+
+Run: `yarn prettier --check "apps/sm-crm-fn/**/*.ts" "apps/sm-fe-smcr/lib/**/*.ts"`
+Expected: all matched files use Prettier code style.

--- a/docs/superpowers/specs/2026-07-09-smion-800-crm-error-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-09-smion-800-crm-error-propagation-design.md
@@ -1,0 +1,175 @@
+# SMION-800 — Propagazione errori CRM al Frontend
+
+- **Data:** 2026-07-09
+- **Autore:** LoFrance
+- **Branch:** SMION-800
+- **Stato:** design approvato, in attesa di piano di implementazione
+- **Ambito:** `apps/sm-crm-fn` (Azure Function) + `apps/sm-fe-smcr` (Next.js) — operazione `POST /meetings`
+
+---
+
+## 1. Contesto e problema
+
+Oggi, quando la creazione di un meeting su Dynamics 365 fallisce, l'informazione sulla causa
+**non arriva all'utente**:
+
+- `httpClient.post` lancia `new Error("POST … failed: <status> - <errorBody>")` con il testo grezzo
+  OData di Dynamics.
+- `orchestrator` cattura l'errore dello step, lo salva in `steps[].error`, imposta `success:false`.
+- `meetings/handler.ts` risponde **500** con un `message` **generico** ("Errore durante la creazione
+  dell'appuntamento"); il dettaglio reale resta sepolto in `steps[].error`.
+- Il frontend (`call-management.action.ts`) legge solo `data.message` / `data.error` top-level e mostra
+  un toast generico. La causa reale (es. ente non trovato, contatto non valido, campo rifiutato dal CRM)
+  **non è distinguibile** dall'utente.
+
+**Obiettivo:** propagare al frontend una causa d'errore **strutturata e stabile**, così che l'utente veda
+un messaggio comprensibile, senza accoppiare la Function alla lingua/UX del frontend e senza esporre lo
+schema interno del CRM.
+
+## 2. Decisioni di design (approvate)
+
+| Tema | Decisione |
+|------|-----------|
+| Destinatario del messaggio | **Utente finale** (UI, toast) |
+| Contratto Function → FE | **Codici neutri e stabili** (`code` + `category` + `step`), NON testo italiano |
+| Traduzione in italiano | Responsabilità del **frontend** (disaccoppiamento) |
+| Granularità codici | Codici specifici per caso noto + `category` + fallback `CRM_ERROR`/`UNKNOWN` |
+| Raw detail Dynamics | **Solo server-side** (App Insights + `DiagnosticSession` sanitizzata); MAI nella risposta HTTP |
+| Ambito | Solo `POST /meetings`, con pattern riusabile per estensioni future |
+| Approccio implementativo | **A — classificazione centralizzata** in un `crmErrorMapper` + errore tipizzato `CrmError` |
+
+## 3. Contratto d'errore (Function → FE)
+
+Gli status HTTP restano invariati: **400** per errori di validazione, **500** per fallimento CRM.
+Il corpo della risposta di errore assume questa forma:
+
+```jsonc
+{
+  "success": false,
+  "message": "Errore durante la creazione dell'appuntamento", // legacy, mantenuto per retro-compatibilità
+  "error": {
+    "code": "ACCOUNT_NOT_FOUND",   // stabile e neutro
+    "category": "NOT_FOUND",        // VALIDATION | NOT_FOUND | CRM_REJECTED | CRM_UNAVAILABLE | UNKNOWN
+    "step": "verifyAccount"         // step del flusso in cui è avvenuto l'errore
+  },
+  "timestamp": "2026-07-09T..."
+}
+```
+
+### 3.1 Catalogo codici (v1)
+
+| `code` | `category` | HTTP | Quando accade |
+|--------|-----------|------|---------------|
+| `VALIDATION_ERROR` | `VALIDATION` | 400 | Payload non valido (`validateOrchestratorRequest`) |
+| `ACCOUNT_NOT_FOUND` | `NOT_FOUND` | 500 | Ente non risolto nello step `verifyAccount` |
+| `CONTACT_INVALID` | `NOT_FOUND` | 500 | Contatto non trovato/creabile nello step `verifyOrCreateContacts` |
+| `CRM_FIELD_REJECTED` | `CRM_REJECTED` | 500 | Dynamics rifiuta un campo/valore (es. OData `0x80040265` e simili) |
+| `CRM_UNAVAILABLE` | `CRM_UNAVAILABLE` | 500 | Timeout / 5xx / irraggiungibilità di Dynamics |
+| `CRM_ERROR` | `UNKNOWN` | 500 | Fallback per errore CRM non classificato |
+| `UNKNOWN` | `UNKNOWN` | 500 | Fallback estremo (errore non riconducibile al CRM) |
+
+> Il `rawDetail` (testo OData grezzo, codici `0x8004…`, eventuali nomi di campo/schema) **non** compare
+> mai in `error`. È tracciato esclusivamente in App Insights e nella `DiagnosticSession` (sanitizzata),
+> coerentemente con il fix di sicurezza di SMION-799.
+
+## 4. Componenti (Approccio A)
+
+### 4.1 Function (`apps/sm-crm-fn`)
+
+1. **`_shared/errors/CrmError.ts`** (nuovo)
+   Classe d'errore tipizzata con: `status` (HTTP Dynamics), `odataCode` (es. `0x80040265`),
+   `rawDetail` (testo grezzo), `step?`. Sostituisce il `throw new Error("POST … failed: …")` grezzo.
+
+2. **`_shared/services/crmErrorMapper.ts`** (nuovo — cuore dell'approccio)
+   Funzione pura `mapCrmError(input): { code, category, step }`. Riceve `status` + `odataCode` + `step`
+   e restituisce il codice neutro secondo il catalogo §3.1. **Nessun** testo italiano, **nessuna**
+   dipendenza da HTTP. Unità testabile in isolamento.
+
+3. **`_shared/services/httpClient.ts`** (modifica)
+   Nel ramo `!response.ok`, lancia `new CrmError({ status, odataCode, rawDetail })` invece di `Error`
+   con stringa. Il `rawDetail` continua a essere loggato server-side (App Insights).
+
+4. **`_shared/services/orchestrator.ts`** (modifica minima)
+   Dove già cattura gli errori di step, arricchisce il `CrmError` con lo `step`. Per i casi
+   "non trovato" che oggi non lanciano (es. account/contatto assente), costruisce comunque
+   l'informazione d'errore. Il risultato porta un campo `errorInfo?: { code, category, step }`.
+
+5. **`meetings/handler.ts`** (modifica)
+   Popola `error: { code, category, step }` nella risposta usando `mapCrmError`. Logga il `rawDetail`
+   solo server-side. Mantiene `message` legacy.
+
+6. **`__tests__/crmErrorMapper.test.ts`** (nuovo)
+   Un test per ogni ramo del catalogo + fallback; verifica che `rawDetail` non compaia nell'output.
+
+### 4.2 Frontend (`apps/sm-fe-smcr`)
+
+7. **`lib/crm-error-messages.ts`** (nuovo)
+   Dizionario `code → messaggio IT` + `getCrmErrorMessage(code?)` con fallback generico
+   ("Errore CRM, contatta il supporto"). **Unico punto** con testi in italiano.
+
+8. **`lib/actions/call-management.action.ts`** (modifica)
+   Estrae `data.error?.code`; ritorna `{ success:false, error: getCrmErrorMessage(code) }`.
+   Mantiene la firma attuale → nessun cambio a `crm-form.tsx` (che già fa `toast.error(crmResult.error)`).
+
+### 4.3 Boundary
+
+- `crmErrorMapper` non conosce HTTP né italiano.
+- `handler` non conosce le stringhe OData grezze.
+- Il frontend non conosce Dynamics: consuma solo `code`.
+
+## 5. Flusso dati
+
+```
+Dynamics 4xx/5xx  ─►  httpClient.post lancia CrmError{status,odataCode,rawDetail}
+                       (rawDetail → App Insights, NON in risposta)
+        │
+        ▼
+orchestrator: catch step → arricchisce CrmError con step="verifyAccount"
+              (per i casi "not found" senza throw, costruisce comunque il code)
+        │
+        ▼
+handler: mapCrmError(...) → { code:"ACCOUNT_NOT_FOUND", category:"NOT_FOUND", step }
+         risposta 500 (o 400 per VALIDATION) con error:{...}, raw solo nei log
+        │
+        ▼
+FE call-management.action: estrae data.error.code (fallback su message legacy)
+        │
+        ▼
+crm-form.tsx: toast.error( getCrmErrorMessage(code) )   ← unico punto con testi IT
+```
+
+## 6. Casi limite
+
+- **`error` assente** (successo, o vecchia risposta): il FE usa il `message` legacy → nessuna regressione.
+- **`code` sconosciuto** al FE: fallback "Errore CRM, contatta il supporto".
+- **Fallback `0x80040265`** già presente in `appointments.ts`: resta invariato; se dopo il fallback
+  l'esito è success, **nessun** errore propagato (comportamento attuale preservato).
+- **207 Multi-Status** (warnings, meeting creato): resta `success:true` → nessun `error`;
+  i warnings non diventano errori.
+
+## 7. Testing
+
+**Function (Jest):**
+- `crmErrorMapper.test.ts`: un test per ramo (`VALIDATION_ERROR`, `ACCOUNT_NOT_FOUND`, `CONTACT_INVALID`,
+  `CRM_FIELD_REJECTED`, `CRM_UNAVAILABLE`, fallback `CRM_ERROR`/`UNKNOWN`); assert che `rawDetail` non
+  sia nell'output.
+- `CrmError`: costruttore/proprietà.
+- Handler: la risposta d'errore contiene `error.{code,category,step}` e **non** il raw detail
+  (guard anti-regressione del finding SMION-799).
+
+**Frontend:**
+- Test del dizionario: code noto → testo corretto; code sconosciuto → fallback.
+
+## 8. Documentazione
+
+- **`apps/sm-crm-fn/docs/FE_ERROR_CODES_GUIDE.md`** (nuovo): guida per chi implementa il frontend —
+  tabella `code | category | HTTP status | quando accade | messaggio IT suggerito`, esempi JSON di
+  risposta, indicazioni su fallback e retro-compatibilità.
+- Aggiornare `apps/sm-crm-fn/docs/API_GUIDE.md` e/o `openapi.yaml` dove documentano lo schema di risposta
+  di `POST /meetings`, aggiungendo l'oggetto `error`.
+
+## 9. Fuori ambito (YAGNI)
+
+- Propagazione errori per accounts/contacts/lista meeting (rimandata; il pattern resta riusabile).
+- Internazionalizzazione multi-lingua nel frontend (solo italiano per ora).
+- Retry automatici lato frontend (`retriable` non incluso nel contratto v1).


### PR DESCRIPTION
Introduce un **contratto d'errore neutro e stabile dalla Azure Function verso il frontend**, senza esporre dettagli grezzi di Dynamics.

Cosa cambia

• La Function, in caso di errore su  POST /meetings , restituisce un oggetto  error: { code, category, step }  neutro (es.  ACCOUNT_NOT_FOUND ,  CRM_UNAVAILABLE ,  CRM_FIELD_REJECTED …).
• Il dettaglio grezzo (URL interni, body OData, messaggi eccezione) resta solo nei log server-side, mai nella risposta HTTP.
• Il frontend traduce il  code  in messaggio italiano user-facing ( getCrmErrorMessage ), con fallback generico per codici sconosciuti.
• Nuovo  CrmError  tipizzato +  crmErrorMapper  puro;  httpClient  (GET/POST) lancia errori neutri.


Cosa deve fare il FE:

1. Leggere  data.error?.code  dalla risposta di errore della Function.
2. Mapparlo sul messaggio italiano con  getCrmErrorMessage(code)  (già pronto in  lib/crm-error-messages.ts ).
3. Se  error  è assente (risposta legacy) → usare  data.message . Per un  code  sconosciuto → fallback generico automatico.

Forma della risposta:

```json
{ 
  "success": false, 
  "error": 
    { 
      "code": "ACCOUNT_NOT_FOUND", 
      "category": "NOT_FOUND", "step": "verifyAccount" 
    }, 
  "message": "…", "timestamp": "…" 
}
```

Codici supportati:


code | category | HTTP | Messaggio IT
-- | -- | -- | --
VALIDATION_ERROR | VALIDATION | 400 | Alcuni dati inseriti non sono validi. Controlla i campi e riprova.
ACCOUNT_NOT_FOUND | NOT_FOUND | 500 | Ente non trovato nel CRM. Verifica l'ente selezionato.
CONTACT_INVALID | NOT_FOUND | 500 | Contatto non valido o non trovato nel CRM. Verifica i partecipanti.
CRM_FIELD_REJECTED | CRM_REJECTED | 500 | Il CRM ha rifiutato uno dei valori inviati. Contatta il supporto.
CRM_UNAVAILABLE | CRM_UNAVAILABLE | 500 | Il CRM non è al momento raggiungibile. Riprova più tardi.
CRM_ERROR | UNKNOWN | 500 | Errore CRM. Riprova più tardi o contatta il supporto.
UNKNOWN | UNKNOWN | 500 | Errore CRM. Riprova più tardi o contatta il supporto.



**Regola chiave**: prevedere sempre il fallback generico per codici non riconosciuti — in futuro se ne possono aggiungere di nuovi senza rompere il FE. 

Dettagli completi in  apps/sm-crm-fn/docs/FE_ERROR_CODES_GUIDE.md .