### PR TITLE
[SMION-809] Dettaglio e-service e descriptor PDND nel Wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,11 @@ temp
 AzuriteConfig
 
 terraform.tfvars
+.vexpignore
+.gitignore
+.claude/hooks/vexp-guard.sh
+.vexp/.gitattributes
+.gitignore
+.vexp/daemon.log.1
+vexp.toml
+.claude

--- a/apps/sm-fe-smcr/app/api/pdnd/eservice-descriptor/route.ts
+++ b/apps/sm-fe-smcr/app/api/pdnd/eservice-descriptor/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
+import { pdndFetch } from "@/lib/pdnd";
+
+export const dynamic = "force-dynamic";
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const eserviceId = searchParams.get("eserviceId");
+  const descriptorId = searchParams.get("descriptorId");
+
+  if (!eserviceId || !descriptorId) {
+    return NextResponse.json(
+      { error: "Missing required query parameters: eserviceId, descriptorId" },
+      { status: 400 },
+    );
+  }
+
+  if (!uuidPattern.test(eserviceId) || !uuidPattern.test(descriptorId)) {
+    return NextResponse.json(
+      { error: "Invalid eserviceId or descriptorId format" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const pdndResponse = await pdndFetch(
+      `/${serverEnv.PDND_API_VERSION}/eservices/${eserviceId}/descriptors/${descriptorId}`,
+    );
+    const contentType = pdndResponse.headers.get("content-type") ?? "";
+
+    if (!pdndResponse.ok) {
+      const body = await pdndResponse.text();
+      return new Response(body, {
+        status: pdndResponse.status,
+        headers: { "Content-Type": contentType || "application/json" },
+      });
+    }
+
+    const data = await pdndResponse.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    logServerError(error, "PDND get e-service descriptor error");
+    return NextResponse.json(
+      { error: "Errore durante il recupero del descriptor e-service" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/sm-fe-smcr/app/api/pdnd/eservice-interface/route.ts
+++ b/apps/sm-fe-smcr/app/api/pdnd/eservice-interface/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { serverEnv } from "@/config/env";
 import { logServerError } from "@/lib/logger/logger.server.helpers";
 import { pdndFetch } from "@/lib/pdnd";
 
@@ -65,7 +66,7 @@ export async function GET(request: Request) {
 
   try {
     const pdndResponse = await pdndFetch(
-      `/v2/eservices/${eserviceId}/descriptors/${descriptorId}/interface`,
+      `/${serverEnv.PDND_API_VERSION}/eservices/${eserviceId}/descriptors/${descriptorId}/interface`,
     );
     const responseContentType = pdndResponse.headers.get("content-type") ?? "";
 

--- a/apps/sm-fe-smcr/app/api/pdnd/eservice/route.ts
+++ b/apps/sm-fe-smcr/app/api/pdnd/eservice/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+
+import { serverEnv } from "@/config/env";
+import { logServerError } from "@/lib/logger/logger.server.helpers";
+import { pdndFetch } from "@/lib/pdnd";
+
+export const dynamic = "force-dynamic";
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const eserviceId = searchParams.get("eserviceId");
+
+  if (!eserviceId) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: eserviceId" },
+      { status: 400 },
+    );
+  }
+
+  if (!uuidPattern.test(eserviceId)) {
+    return NextResponse.json(
+      { error: "Invalid eserviceId format" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const pdndResponse = await pdndFetch(
+      `/${serverEnv.PDND_API_VERSION}/eservices/${eserviceId}`,
+    );
+    const contentType = pdndResponse.headers.get("content-type") ?? "";
+
+    if (!pdndResponse.ok) {
+      const body = await pdndResponse.text();
+      return new Response(body, {
+        status: pdndResponse.status,
+        headers: { "Content-Type": contentType || "application/json" },
+      });
+    }
+
+    const data = await pdndResponse.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    logServerError(error, "PDND get e-service error");
+    return NextResponse.json(
+      { error: "Errore durante il recupero dell'e-service" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/sm-fe-smcr/config/env.ts
+++ b/apps/sm-fe-smcr/config/env.ts
@@ -53,6 +53,7 @@ const serverEnvSchema = z.object({
 
   // PDND Interoperabilita DPoP client
   PDND_ENV: optionalString,
+  PDND_API_VERSION: z.string().default("v3"),
   PDND_CLIENT_ID: optionalString,
   PDND_CLIENT_ASSERTION_KID: optionalString,
   PDND_CLIENT_ASSERTION_AUDIENCE: optionalString,
@@ -139,6 +140,7 @@ const rawServerEnv = {
   GET_IPA_UO: process.env.GET_IPA_UO,
   GET_INFOCAMERE: process.env.GET_INFOCAMERE,
   PDND_ENV: process.env.PDND_ENV,
+  PDND_API_VERSION: process.env.PDND_API_VERSION,
   PDND_CLIENT_ID: process.env.PDND_CLIENT_ID,
   PDND_CLIENT_ASSERTION_KID: process.env.PDND_CLIENT_ASSERTION_KID,
   PDND_CLIENT_ASSERTION_AUDIENCE: process.env.PDND_CLIENT_ASSERTION_AUDIENCE,

--- a/apps/sm-fe-smcr/config/env.ts
+++ b/apps/sm-fe-smcr/config/env.ts
@@ -53,7 +53,7 @@ const serverEnvSchema = z.object({
 
   // PDND Interoperabilita DPoP client
   PDND_ENV: optionalString,
-  PDND_API_VERSION: z.string().default("v3"),
+  PDND_API_VERSION: z.string().trim().min(1).default("v3").catch("v3"),
   PDND_CLIENT_ID: optionalString,
   PDND_CLIENT_ASSERTION_KID: optionalString,
   PDND_CLIENT_ASSERTION_AUDIENCE: optionalString,

--- a/apps/sm-fe-smcr/env.example
+++ b/apps/sm-fe-smcr/env.example
@@ -45,6 +45,7 @@ GET_USERS_PATH=your/api/path/users
 
 # ─── PDND Interoperabilita DPoP client ───
 PDND_ENV=your-pdnd-environment
+PDND_API_VERSION=v3
 PDND_CLIENT_ID=your-pdnd-client-id
 PDND_CLIENT_ASSERTION_KID=your-pdnd-client-assertion-key-id
 PDND_CLIENT_ASSERTION_AUDIENCE=your-pdnd-client-assertion-audience

--- a/apps/sm-fe-smcr/features/wallet/table/columns.tsx
+++ b/apps/sm-fe-smcr/features/wallet/table/columns.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Check, Copy, Download, Landmark } from "lucide-react";
-import { ComponentProps, useState } from "react";
+import { Download, Landmark } from "lucide-react";
+import { ComponentProps } from "react";
 import { ColumnDef } from "@tanstack/react-table";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { PdndDetailDialog } from "@/features/wallet/table/pdnd-detail-dialog";
 import type { WalletRow } from "@/lib/services/wallet.service";
 import { cn } from "@/lib/utils";
 
@@ -93,10 +94,6 @@ function fmtTime(iso: string) {
   return d.toLocaleTimeString("it-IT", { hour: "2-digit", minute: "2-digit" });
 }
 
-function shortId(id: string) {
-  return id.slice(0, 8);
-}
-
 type SortKey = "name" | "nomeEnte" | "state" | "createdat";
 type SortDir = "asc" | "desc";
 
@@ -109,33 +106,22 @@ function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
   );
 }
 
-function UuidChip({ id }: { id: string }) {
-  const [copied, setCopied] = useState(false);
-  const onCopy = async () => {
-    try {
-      await navigator.clipboard?.writeText(id);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1200);
-    } catch {
-      // no-op
-    }
-  };
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      onClick={onCopy}
-      title={id}
-      className="bg-muted/60 hover:bg-muted/60 hover:border-primary hover:text-primary h-auto gap-1.5 rounded-md border px-2 py-1 font-normal transition-colors has-[>svg]:px-2"
-    >
-      <span className="font-mono text-xs">{shortId(id)}</span>
-      {copied ? (
-        <Check className="size-3" />
-      ) : (
-        <Copy className="size-3 opacity-60" />
-      )}
-    </Button>
-  );
+function getEserviceDetailUrl(row: WalletRow): string {
+  const params = new URLSearchParams({ eserviceId: row.id });
+  return `/api/pdnd/eservice?${params.toString()}`;
+}
+
+function getDescriptorDetailUrl(row: WalletRow): string | null {
+  if (!row.descriptorid) {
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    eserviceId: row.id,
+    descriptorId: row.descriptorid,
+  });
+
+  return `/api/pdnd/eservice-descriptor?${params.toString()}`;
 }
 
 function getInterfaceDownloadUrl(row: WalletRow): string | null {
@@ -165,17 +151,30 @@ export function createWalletColumns({
     {
       accessorKey: "id",
       header: "ID",
-      cell: ({ row }) => <UuidChip id={row.original.id} />,
+      cell: ({ row }) => (
+        <PdndDetailDialog
+          endpoint={getEserviceDetailUrl(row.original)}
+          id={row.original.id}
+          title="Dettaglio e-service"
+        />
+      ),
     },
     {
       accessorKey: "descriptorid",
       header: "Descriptor ID",
-      cell: ({ row }) =>
-        row.original.descriptorid ? (
-          <UuidChip id={row.original.descriptorid} />
+      cell: ({ row }) => {
+        const endpoint = getDescriptorDetailUrl(row.original);
+
+        return endpoint && row.original.descriptorid ? (
+          <PdndDetailDialog
+            endpoint={endpoint}
+            id={row.original.descriptorid}
+            title="Dettaglio versione (descriptor)"
+          />
         ) : (
           <span className="text-muted-foreground text-xs">—</span>
-        ),
+        );
+      },
     },
     {
       accessorKey: "name",

--- a/apps/sm-fe-smcr/features/wallet/table/pdnd-detail-dialog.tsx
+++ b/apps/sm-fe-smcr/features/wallet/table/pdnd-detail-dialog.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+function shortId(id: string) {
+  return id.slice(0, 8);
+}
+
+// Etichette note per i campi di EService (getEservice) e Descriptor (getVersion).
+// I campi non mappati usano la chiave così com'è (fallback tollerante).
+const fieldLabels: Record<string, string> = {
+  id: "ID",
+  producerId: "ID erogatore",
+  name: "Nome",
+  description: "Descrizione",
+  technology: "Tecnologia",
+  mode: "Modalità",
+  isSignalHubEnabled: "Signal Hub",
+  isConsumerDelegable: "Delega fruitore",
+  isClientAccessDelegable: "Delega accesso client",
+  personalData: "Dati personali",
+  asyncExchange: "Scambio asincrono",
+  version: "Versione",
+  audience: "Audience",
+  voucherLifespan: "Durata voucher (s)",
+  dailyCallsPerConsumer: "Chiamate/giorno per fruitore",
+  dailyCallsTotal: "Chiamate/giorno totali",
+  state: "Stato",
+  agreementApprovalPolicy: "Policy approvazione",
+  serverUrls: "Server URL",
+  publishedAt: "Pubblicato il",
+};
+
+const isoDatePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+
+function formatValue(value: unknown) {
+  if (value == null || value === "") {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Sì" : "No";
+  }
+
+  if (typeof value === "string") {
+    if (isoDatePattern.test(value)) {
+      return new Date(value).toLocaleString("it-IT", {
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    }
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value.toLocaleString("it-IT");
+  }
+
+  if (Array.isArray(value) && value.every((item) => typeof item !== "object")) {
+    return (
+      <ul className="list-disc space-y-0.5 pl-4">
+        {value.map((item, index) => (
+          <li key={index} className="break-all">
+            {String(item)}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <pre className="bg-muted/50 overflow-x-auto rounded-md p-2 text-xs">
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}
+
+function PdndDetailView({ data }: { data: unknown }) {
+  if (data == null || typeof data !== "object") {
+    return <pre className="text-xs">{String(data)}</pre>;
+  }
+
+  const entries = Object.entries(data as Record<string, unknown>);
+
+  return (
+    <dl className="divide-y">
+      {entries.map(([key, value]) => (
+        <div key={key} className="grid grid-cols-3 gap-3 py-2">
+          <dt className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            {fieldLabels[key] ?? key}
+          </dt>
+          <dd className="col-span-2 break-words text-sm">
+            {formatValue(value)}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+type PdndDetailDialogProps = {
+  endpoint: string;
+  id: string;
+  title: string;
+};
+
+export function PdndDetailDialog({ endpoint, id, title }: PdndDetailDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<unknown>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(endpoint);
+      const body: unknown = await res.json().catch(() => null);
+
+      if (!res.ok) {
+        const message =
+          body &&
+          typeof body === "object" &&
+          "error" in body &&
+          typeof (body as { error: unknown }).error === "string"
+            ? (body as { error: string }).error
+            : `Errore ${res.status}`;
+        setError(message);
+        setData(null);
+        return;
+      }
+
+      setData(body);
+    } catch {
+      setError("Errore di rete durante la chiamata a PDND");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function onOpenChange(next: boolean) {
+    setOpen(next);
+    if (next && data === null && !loading) {
+      void load();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          title={id}
+          className="bg-muted/60 hover:bg-muted/60 hover:border-primary hover:text-primary h-auto gap-1.5 rounded-md border px-2 py-1 font-normal transition-colors has-[>svg]:px-2"
+        >
+          <span className="font-mono text-xs">{shortId(id)}</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] max-w-2xl overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription className="break-all font-mono text-xs">
+            {id}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="overflow-auto">
+          {loading && (
+            <div className="text-muted-foreground flex items-center gap-2 py-8 text-sm">
+              <Loader2 className="size-4 animate-spin" /> Caricamento da PDND…
+            </div>
+          )}
+          {error && !loading && (
+            <p className="text-destructive py-8 text-sm">{error}</p>
+          )}
+          {!loading && !error && data != null && <PdndDetailView data={data} />}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/sm-fe-smcr/lib/pdnd/__tests__/pdnd.test.ts
+++ b/apps/sm-fe-smcr/lib/pdnd/__tests__/pdnd.test.ts
@@ -157,7 +157,7 @@ describe("PDND DPoP client", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("sends Bearer authorization and per-request DPoP headers in pdndFetch", async () => {
+  it("sends DPoP authorization and per-request DPoP headers in pdndFetch", async () => {
     const config = createTestConfig();
     const fetchMock = jest
       .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
@@ -193,7 +193,7 @@ describe("PDND DPoP client", () => {
     expect(url.toString()).toBe(
       "https://api-coll.interop.pagopa.it/v3/eservices?offset=0",
     );
-    expect(headers.get("Authorization")).toBe("Bearer test-access-token");
+    expect(headers.get("Authorization")).toBe("DPoP test-access-token");
     expect(decodedDpop.payload).toMatchObject({
       htm: "GET",
       htu: "https://api-coll.interop.pagopa.it/v3/eservices",

--- a/apps/sm-fe-smcr/lib/pdnd/fetch.ts
+++ b/apps/sm-fe-smcr/lib/pdnd/fetch.ts
@@ -42,7 +42,7 @@ export async function pdndFetch(
     nowSeconds: options.nowSeconds,
   });
   const headers = new Headers(init.headers);
-  headers.set("Authorization", `Bearer ${voucher.accessToken}`);
+  headers.set("Authorization", `DPoP ${voucher.accessToken}`);
   headers.set("DPoP", dpopProof);
 
   return fetchImpl(url, {

--- a/scripts/pull-pdnd-env.sh
+++ b/scripts/pull-pdnd-env.sh
@@ -40,6 +40,8 @@ printf '%s' "$PAIRS" | while read -r env_name secret_name; do
   fi
   # newline reali (chiavi PEM) -> \n letterali, come si aspetta normalizePem()
   val="$(printf '%s' "$val" | perl -0pe 's/\n/\\n/g')"
+  # escape dei doppi apici, così un valore con " non rompe la riga .env
+  val="${val//\"/\\\"}"
   printf '%s="%s"\n' "$env_name" "$val" >> "$OUT"
   echo "✅ $env_name"
 done

--- a/scripts/pull-pdnd-env.sh
+++ b/scripts/pull-pdnd-env.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Estrae i 11 secret PDND dal Key Vault e li accoda a apps/sm-fe-smcr/.env.local
+# Uso:  az login --tenant 7788edaf-0346-4068-9d79-c868aed15b3d
+#       bash scripts/pull-pdnd-env.sh
+set -euo pipefail
+
+KV="plsm-p-itn-common-kv-01"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$REPO_ROOT/apps/sm-fe-smcr/.env.local"
+
+# ENV_NAME  SECRET_NAME (uno per riga)
+PAIRS="
+PDND_ENV fe-smcr-pdnd-env
+PDND_CLIENT_ID fe-smcr-pdnd-client-id
+PDND_CLIENT_ASSERTION_KID fe-smcr-pdnd-client-assertion-kid
+PDND_CLIENT_ASSERTION_AUDIENCE fe-smcr-pdnd-client-assertion-audience
+PDND_AUTH_TOKEN_URL fe-smcr-pdnd-auth-token-url
+PDND_API_BASE_URL fe-smcr-pdnd-api-base-url
+PDND_CLIENT_ASSERTION_PRIVATE_KEY fe-smcr-pdnd-client-assertion-private-key
+PDND_DPOP_PRIVATE_KEY fe-smcr-pdnd-dpop-private-key
+PDND_CLIENT_ASSERTION_TTL_SECONDS fe-smcr-pdnd-client-assertion-ttl-seconds
+PDND_TOKEN_REFRESH_MARGIN_SECONDS fe-smcr-pdnd-token-refresh-margin-seconds
+PDND_REQUEST_TIMEOUT_MS fe-smcr-pdnd-request-timeout-ms
+"
+
+if ! az account show >/dev/null 2>&1; then
+  echo "❌ Non sei autenticato su az. Esegui prima:"
+  echo "   az login --tenant 7788edaf-0346-4068-9d79-c868aed15b3d"
+  exit 1
+fi
+
+echo "# ─── PDND Interoperabilità DPoP client (estratti da $KV il $(date +%F)) ───" >> "$OUT"
+
+printf '%s' "$PAIRS" | while read -r env_name secret_name; do
+  [ -z "$env_name" ] && continue
+  val="$(az keyvault secret show --vault-name "$KV" --name "$secret_name" --query value -o tsv)"
+  if [ -z "$val" ]; then
+    echo "⚠️  $secret_name è vuoto o non accessibile" >&2
+    continue
+  fi
+  # newline reali (chiavi PEM) -> \n letterali, come si aspetta normalizePem()
+  val="$(printf '%s' "$val" | perl -0pe 's/\n/\\n/g')"
+  printf '%s="%s"\n' "$env_name" "$val" >> "$OUT"
+  echo "✅ $env_name"
+done
+
+echo "Fatto. Scritte in: $OUT"


### PR DESCRIPTION
## Cosa cambia
**Feature (criteri di accettazione #1 e #2)**
- Nuova route `GET /api/pdnd/eservice` → getEservice (`/{version}/eservices/{id}`)
- Nuova route `GET /api/pdnd/eservice-descriptor` → getVersion
  (`/{version}/eservices/{id}/descriptors/{descriptorId}`)
- Modale `pdnd-detail-dialog` con fetch lazy, stati loading/errore e render
  con etichette in italiano (booleani come Sì/No, array come elenco, date
  formattate)
- Rimossi i chip "copia UUID" dalle due colonne, ora cliccabili

**Refactor — versione API configurabile**
- Aggiunta `PDND_API_VERSION` a `serverEnv` (default `v3`); nessun prefisso di
  versione hardcoded nei path
- Corretta la route `eservice-interface`, rimasta su `/v2` per un copy-paste
  da un esempio

**Fix del client condiviso (introdotto in #315)**
- `lib/pdnd/fetch.ts`: la v3 richiede `Authorization: DPoP <token>`, non
  `Bearer`. Con `Bearer` ogni chiamata reale falliva con 400 "Bad DPoP Token
  format"; gli unit test non lo prendevano perché mockano `fetch`. Test
tta corretta.

## Verifica
Testato end-to-end contro **PDND prod** (nessuna VPN necessaria, API pubblica):
- `getEservice` → `200` con dati reali (es. "DGMOT-Patn_IT-Wallet")
- `getVersion` → `200` con dati reali (versione 1, `PUBLISHED`, quote, audience)
- typecheck + lint + unit test PDND verdi