### PR TITLE
[SMION-818] Fix auth redirect loop

### DIFF
--- a/apps/sm-fe-smcr/app/api/auth/logout/__tests__/route.test.ts
+++ b/apps/sm-fe-smcr/app/api/auth/logout/__tests__/route.test.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+describe("GET /api/auth/logout", () => {
+  beforeEach(() => {
+    process.env.AUTH_FUNCTION_BASE_URL =
+      "https://plsm-p-itn-auth-func-01.azurewebsites.net";
+    jest.spyOn(global, "fetch").mockResolvedValue(new Response(null));
+  });
+
+  afterEach(() => {
+    delete process.env.AUTH_FUNCTION_BASE_URL;
+    jest.restoreAllMocks();
+  });
+
+  it("redirects to the public App Service origin instead of the internal container host", async () => {
+    const request = new NextRequest(
+      "https://eca33f6936bd:8080/api/auth/logout",
+      {
+        headers: {
+          "disguised-host": "smcr.pagopa.it",
+          "x-forwarded-proto": "https",
+        },
+      },
+    );
+
+    const response = await GET(request);
+
+    expect(response.headers.get("location")).toBe("https://smcr.pagopa.it/");
+  });
+});

--- a/apps/sm-fe-smcr/app/api/auth/logout/route.ts
+++ b/apps/sm-fe-smcr/app/api/auth/logout/route.ts
@@ -3,6 +3,7 @@ import { AUTH_COOKIE_NAME, AUTH_COOKIE_NAMES } from "@/lib/auth/constants";
 import {
   buildAuthFunctionUrl,
   buildForwardCookieHeader,
+  getPublicOrigin,
   getRequestIsSecure,
 } from "@/lib/auth/proxy";
 
@@ -27,7 +28,7 @@ export async function GET(request: NextRequest) {
 
   await notifyAuthFunction(request);
 
-  const response = NextResponse.redirect(new URL("/", request.url));
+  const response = NextResponse.redirect(new URL("/", getPublicOrigin(request)));
 
   for (const cookieName of AUTH_COOKIE_NAMES) {
     response.cookies.set({

--- a/apps/sm-fe-smcr/app/unauthorized/page.tsx
+++ b/apps/sm-fe-smcr/app/unauthorized/page.tsx
@@ -17,7 +17,7 @@ export default function UnauthorizedPage() {
           <br />
           Se pensi si tratti di un errore, contatta l’amministratore.
         </p>
-        <Link href="/">
+        <Link href="/api/auth/logout">
           <Button className="bg-red-600 hover:bg-red-700 transition-colors">
             Effettua il Login
           </Button>

--- a/apps/sm-fe-smcr/app/unauthorized/page.tsx
+++ b/apps/sm-fe-smcr/app/unauthorized/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { ShieldAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -17,11 +16,12 @@ export default function UnauthorizedPage() {
           <br />
           Se pensi si tratti di un errore, contatta l’amministratore.
         </p>
-        <Link href="/api/auth/logout">
-          <Button className="bg-red-600 hover:bg-red-700 transition-colors">
-            Effettua il Login
-          </Button>
-        </Link>
+        <Button
+          asChild
+          className="bg-red-600 hover:bg-red-700 transition-colors"
+        >
+          <a href="/api/auth/logout">Effettua il Login</a>
+        </Button>
       </div>
     </div>
   );

--- a/apps/sm-fe-smcr/context/sessionProvider.tsx
+++ b/apps/sm-fe-smcr/context/sessionProvider.tsx
@@ -100,55 +100,83 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      const userProfile = await fetchUserProfile();
-
-      // Check if member exists in the new members table, create if not
-      const memberResult = await readMemberByEmail(claims.email);
-      if (memberResult.error || !memberResult.data) {
-        void clientLogger.info(
-          {
-            info: {
-              event: "session.member.create_missing",
-              metadata: { email: claims.email },
-            },
-          },
-          "Member not found, creating new member",
-        );
-
-        const { firstname, lastname } = splitDisplayName(claims.name);
-
-        const createResult = await createMember({
-          email: claims.email,
-          firstname,
-          lastname,
-        });
-
-        if (createResult.error) {
-          void clientLogger.error(
-            { error: createResult.error },
-            "Failed to create member",
-          );
-        } else {
-          void clientLogger.info("Member created successfully");
-        }
-      }
-
-      // const userTeams = await getUserTeams(userProfile.id);
-      const userMember = await getUserMember(userProfile.id);
-      const userPreferences = await getUserPreferences(userProfile.id);
-      setUser({
-        ...userProfile,
+      // Sessione valida: se l'arricchimento del profilo fallisce l'utente resta
+      // comunque autenticato. Un profilo minimo dai claim evita che un errore
+      // transitorio (DB a freddo, timeout) venga scambiato per "non autenticato"
+      // dal guard di rotta, che manderebbe l'utente su /unauthorized.
+      const fallbackUser: UserProfile = {
+        id: claims.userId,
         email: claims.email,
         name: claims.name,
-        membersOf: userMember,
+        membersOf: [],
         activeTeam: null,
-        preferences: {
-          teamId: userPreferences.teamId,
-          theme: userPreferences.theme,
-        },
-      });
+        preferences: { teamId: null, theme: "system" },
+      };
+
+      try {
+        const userProfile = await fetchUserProfile();
+
+        // Check if member exists in the new members table, create if not
+        const memberResult = await readMemberByEmail(claims.email);
+        if (memberResult.error || !memberResult.data) {
+          void clientLogger.info(
+            {
+              info: {
+                event: "session.member.create_missing",
+                metadata: { email: claims.email },
+              },
+            },
+            "Member not found, creating new member",
+          );
+
+          const { firstname, lastname } = splitDisplayName(claims.name);
+
+          const createResult = await createMember({
+            email: claims.email,
+            firstname,
+            lastname,
+          });
+
+          if (createResult.error) {
+            void clientLogger.error(
+              { error: createResult.error },
+              "Failed to create member",
+            );
+          } else {
+            void clientLogger.info("Member created successfully");
+          }
+        }
+
+        // const userTeams = await getUserTeams(userProfile.id);
+        const userMember = await getUserMember(userProfile.id);
+        const userPreferences = await getUserPreferences(userProfile.id);
+        setUser({
+          ...userProfile,
+          email: claims.email,
+          name: claims.name,
+          membersOf: userMember,
+          activeTeam: null,
+          preferences: {
+            teamId: userPreferences.teamId,
+            theme: userPreferences.theme,
+          },
+        });
+      } catch (enrichError: any) {
+        // Autenticato ma arricchimento fallito: degradazione morbida, niente
+        // logout. L'utente accede alle rotte senza vincoli di team; quelle
+        // team-gated ricadono su "insufficient_permissions" (→ /dashboard),
+        // non su "not_authenticated" (→ /unauthorized).
+        void clientLogger.error(
+          { error: enrichError },
+          "Errore caricamento profilo: sessione valida, uso profilo minimo dai claim",
+        );
+        setError(enrichError.message || "Errore caricamento profilo");
+        setUser(fallbackUser);
+      }
     } catch (err: any) {
-      void clientLogger.error({ error: err }, "Errore caricamento profilo");
+      // Errore nel recupero dei claim (/api/auth/me non 401): stato della
+      // sessione non determinabile, trattato come non autenticato.
+      void clientLogger.error({ error: err }, "Errore verifica sessione");
       setError(err.message || "Errore sconosciuto");
       setUser(null);
     } finally {

--- a/apps/sm-fe-smcr/context/sessionProvider.tsx
+++ b/apps/sm-fe-smcr/context/sessionProvider.tsx
@@ -101,20 +101,16 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       }
 
       // Sessione valida: se l'arricchimento del profilo fallisce l'utente resta
-      // comunque autenticato. Un profilo minimo dai claim evita che un errore
-      // transitorio (DB a freddo, timeout) venga scambiato per "non autenticato"
-      // dal guard di rotta, che manderebbe l'utente su /unauthorized.
-      const fallbackUser: UserProfile = {
-        id: claims.userId,
-        email: claims.email,
-        name: claims.name,
-        membersOf: [],
-        activeTeam: null,
-        preferences: { teamId: null, theme: "system" },
-      };
+      // comunque autenticato, con un profilo minimo. Un errore transitorio (DB
+      // a freddo, timeout) non deve essere scambiato per "non autenticato" dal
+      // guard di rotta, che manderebbe l'utente su /unauthorized.
+      // userProfile è dichiarato qui fuori per poterne preservare l'id (dal DB,
+      // via /api/user/profile) nel fallback quando la fetch è già riuscita;
+      // claims.userId (id di sessione) resta solo come ultima risorsa.
+      let userProfile: Pick<UserProfile, "email" | "id" | "name"> | undefined;
 
       try {
-        const userProfile = await fetchUserProfile();
+        userProfile = await fetchUserProfile();
 
         // Check if member exists in the new members table, create if not
         const memberResult = await readMemberByEmail(claims.email);
@@ -171,7 +167,14 @@ export function SessionProvider({ children }: { children: ReactNode }) {
           "Errore caricamento profilo: sessione valida, uso profilo minimo dai claim",
         );
         setError(enrichError.message || "Errore caricamento profilo");
-        setUser(fallbackUser);
+        setUser({
+          id: userProfile?.id ?? claims.userId,
+          email: claims.email,
+          name: claims.name,
+          membersOf: [],
+          activeTeam: null,
+          preferences: { teamId: null, theme: "system" },
+        });
       }
     } catch (err: any) {
       // Errore nel recupero dei claim (/api/auth/me non 401): stato della


### PR DESCRIPTION

## Fix A — file context/sessionProvider.tsx:

`refreshUserData` azzerava `user` su qualsiasi errore delle fetch di arricchimento (profilo/member/preferences), e `useRouteAccess` leggeva `user=null` come "not_authenticated", mandando su `/unauthorized` un utente in realtà loggato. Ora, se i claim di `/api/auth/me` sono validi, un fallimento di arricchimento degrada a un profilo minimo dai claim invece di annullare la sessione.

## Fix B — file app/unauthorized/page.tsx:


Il bottone "Effettua il Login" puntava a "/", che con un cookie ancora valido rimanda a `/dashboard` e rientra nel loop. Ora punta a `/api/auth/logout`, che azzera i cookie di auth prima di tornare al login: l'utente non deve più svuotare i dati del browser a mano.